### PR TITLE
Fix typo on first blog post

### DIFF
--- a/blog/2018-09-14-say-hello-to-gridsome/index.md
+++ b/blog/2018-09-14-say-hello-to-gridsome/index.md
@@ -43,7 +43,7 @@ query Blog {
 You don't need to know GraphQL or Vue to get started with Gridsome - It's a great way to get introduced to both.
 
 
-The GraphQL layer and all the data can be explored in a local GraphQL playground. The playground can usually located at `https://localhost:8080/___explore` when a Gridsome development project is running.
+The GraphQL layer and all the data can be explored in a local GraphQL playground. The playground is usually located at `https://localhost:8080/___explore` when a Gridsome development project is running.
 
 
 


### PR DESCRIPTION
Alternatively, this could say "can be found at"