### PR TITLE
Fix Gatsby.js alternative explanation.

### DIFF
--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -33,4 +33,4 @@ Gridsome follows the [PRPL-pattern by Google.](https://developers.google.com/web
 
 -	**[Nuxt.](https://nuxtjs.org/)** A Universal Vue.js Framework for server side rendered (SSR) apps and websites. It also has a static site generator feature, but the main focus is SSR.
 
--	**[Gatsby.js](https://www.gatsbyjs.org/)**  Gridsome is highly inspired by Gatsby.js (React.js based), which collects data sources and generates a static site from it. Gridsome is an alternative for Vue.js.
+-	**[Gatsby.js](https://www.gatsbyjs.org/)**  Gridsome is highly inspired by Gatsby.js (React.js based), which collects data sources and generates a static site from it. Gridsome is an alternative for Gatsby.js.


### PR DESCRIPTION
I think the author meant Gridsome is an alternative to Gatsby.js instead of Vue.