### PR TITLE
add how to overwrite meta tags to head document

### DIFF
--- a/docs/head.md
+++ b/docs/head.md
@@ -51,6 +51,30 @@ export default {
 </script>
 ```
 
+## How to overwrite from child component
+
+If you need to overwrite meta tags, add `key` property.  
+Gridsome is passing `tagIdKeyName: 'key'` to vue-meta as default option.  
+
+```js
+// parent component
+{
+  metaInfo: {
+    meta: [
+      { key: 'description', name: 'description', content: 'foo' }
+    ]
+  }
+}
+// child component
+{
+  metaInfo: {
+    meta: [
+      { key: 'description', name: 'description', content: 'bar' }
+    ]
+  }
+}
+```
+
 ## Available Properties
 
 |Property  | Description | Link


### PR DESCRIPTION
I don't know where to add or how to write it, but I think it is better that we tell that Gridsome is modifying vue-meta option.

I took a while to notice this.