### PR TITLE
Remove quotes

### DIFF
--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -42,7 +42,7 @@ Here is an example where we add **Vuex** store to the Vue instance.
 import Vuex from 'vuex'
 
 export default function (Vue, {appOptions}) {
-  Vue.use('Vuex')
+  Vue.use(Vuex)
   
   appOptions.store = new Vuex.Store({
     state: {


### PR DESCRIPTION
Passing `"Vuex"` as a string to `Vue.use()` causes it to fail silently

Fixes the issue in gridsome/gridsome#140