### PR TITLE
Deploying with Terminal updated

### DIFF
--- a/docs/deploy-to-zeit-now.md
+++ b/docs/deploy-to-zeit-now.md
@@ -15,13 +15,51 @@ Add these settings where its needed:
 
 ### Deploying with Terminal
 
-1. Follow [this guide](https://zeit.co/docs/v2/getting-started/installation/) to install Now 
-2. Go to your Gridsome project in terminal
-3. Run `gridsome build`to built the site.
-4. Go to the generated dist folder `cd dist`
-5. Type `now` to deploy your site 🎉
+#### Step 1
 
+Install Now globally by typing `npm install -g now` in Terminal.
 
+### Step 2
+
+Create a `now.json` file in the root folder of your project to configure your deployment process.
+
+```JSON
+{
+  "name": "your-gridsome-project",
+  "alias": "your-gridsome-project.com", // or ["aliasOne", "aliasTwo"]
+  "version": 2,
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@now/static-build",
+      "config": { "distDir": "dist" }
+    }
+  ]
+}
+```
+
+#### Step 3
+
+Update `package.json` by adding a new script within the `scripts` object:
+
+```JSON
+{
+  "scripts": {
+    ...
+    "now-build": "npm run build"
+  }
+}
+```
+
+### Step 4
+
+In Terminal, go to the root folder of your project and just type `now`. Within some time (about a few minutes) your project will be uploaded to Now, built right in there and deployed.
+
+### Step 5 (optional)
+
+If an alias was not assigned automatically, assign it manually by typing `now alias your-project-deployment-address.now.sh your-domain.com`. 
+
+That's it!  🎉
 
 ### Other Zeit Now guides:
 


### PR DESCRIPTION
The current text on gridsome.com and zeit.co is not describing all details about deploying to Now. 

Following it, you have to build it locally, then go to `dist` folder, type `now`. Thus it won't find the `now.json` file so you are getting a project named `dist` in Now.

In the new text, it is described how to configure the build process so that you could just type `now` and get the project with the proper name in Now.