### PR TITLE
showing both git-repo blog options

### DIFF
--- a/docs/starters.md
+++ b/docs/starters.md
@@ -20,4 +20,13 @@ The default project that is created with Gridsome CLI.
 
 
 ### Git-repositories
+
+#### gridsome-starter-blog
+`gridsome create my-website https://github.com/gridsome/gridsome-starter-blog.git`
+
+[Learn more](https://github.com/gridsome/gridsome-starter-blog)
+
+#### gridsome-starter-markdown-blog
 `gridsome create my-website https://github.com/gridsome/gridsome-starter-markdown-blog.git`
+
+[Learn more](https://github.com/gridsome/gridsome-starter-markdown-blog)


### PR DESCRIPTION
Would have been helpful for me starting my own blog to have seen both options, and links to, in the docs.