### PR TITLE
refactor: Refactor slot element

### DIFF
--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -4,14 +4,14 @@ Layout components are used to wrap pages. Layouts should contain components like
 
 Layouts are _just_ &nbsp;**.vue components** located in `src/layouts` and need to be [declared as a global](#make-a-layout-global) component or imported per page to be used.
 
-**Every layout requires a `<slot />` component.** This is where the content coming from pages and templates will be inserted. Layouts can have [multiple slots](#multiple-content-slots).
+**Every layout requires a `<slot>` component.** This is where the content coming from pages and templates will be inserted. Layouts can have [multiple slots](#multiple-content-slots).
 
 ```html
 <!-- Layout -->
 <template>
   <div>
     <header />
-    <slot /> <!-- Page content will be inserted here  -->
+    <slot><slot /> <!-- Page content will be inserted here  -->
     <footer />
   </div>
 </template>
@@ -97,7 +97,7 @@ This will pass a Prop to a layout with `sidebar = true`. In the **Layout compone
 <template>
   <div>
     <div class="main-content">
-      <slot />
+      <slot><slot />
     </div>
     <div v-if="sidebar">
       Lets show the sidebar!
@@ -121,7 +121,7 @@ To add multiple slots to a layout you need to name them. In this example we have
   <div>
     <slot /> <!-- Default slot  -->
     <div class="sidebar" v-if="$slots.sidebar">
-      <slot name="sidebar" /> <!-- Sidebar slot  -->
+      <slot name="sidebar"><slot /> <!-- Sidebar slot  -->
     </div>
   </div>
 </template>

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -11,7 +11,7 @@ Layouts are _just_ &nbsp;**.vue components** located in `src/layouts` and need t
 <template>
   <div>
     <header />
-    <slot><slot /> <!-- Page content will be inserted here  -->
+    <slot></slot> <!-- Page content will be inserted here  -->
     <footer />
   </div>
 </template>
@@ -97,7 +97,7 @@ This will pass a Prop to a layout with `sidebar = true`. In the **Layout compone
 <template>
   <div>
     <div class="main-content">
-      <slot><slot />
+      <slot></slot>
     </div>
     <div v-if="sidebar">
       Lets show the sidebar!
@@ -121,7 +121,7 @@ To add multiple slots to a layout you need to name them. In this example we have
   <div>
     <slot /> <!-- Default slot  -->
     <div class="sidebar" v-if="$slots.sidebar">
-      <slot name="sidebar"><slot /> <!-- Sidebar slot  -->
+      <slot name="sidebar"></slot> <!-- Sidebar slot  -->
     </div>
   </div>
 </template>

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -10,7 +10,7 @@
       <g-image :src="image" />
     </div>
     <div class="card__inner">
-      <slot><slot />
+      <slot></slot>
     </div>
     <slot name="outer" />
   </div>

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -10,7 +10,7 @@
       <g-image :src="image" />
     </div>
     <div class="card__inner">
-      <slot />
+      <slot><slot />
     </div>
     <slot name="outer" />
   </div>

--- a/src/components/Feature.vue
+++ b/src/components/Feature.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="feature text-center">
     <div class="feature__inner">
-      <slot><slot />
+      <slot></slot>
     </div>
   </div>
 </template>

--- a/src/components/Feature.vue
+++ b/src/components/Feature.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="feature text-center">
     <div class="feature__inner">
-      <slot />
+      <slot><slot />
     </div>
   </div>
 </template>

--- a/src/components/Section.vue
+++ b/src/components/Section.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="section" :class="sectionClass">
     <div class="section--inner container" :class="sectionClassInner">
-      <slot/>
+      <slot><slot />
     </div>
     <div v-if="dots" class="section__dots-bg dots-bg" />
     <slot name="outer" />

--- a/src/components/Section.vue
+++ b/src/components/Section.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="section" :class="sectionClass">
     <div class="section--inner container" :class="sectionClassInner">
-      <slot><slot />
+      <slot></slot>
     </div>
     <div v-if="dots" class="section__dots-bg dots-bg" />
     <slot name="outer" />

--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="app" dark>
     <Header />
-    <slot />
+    <slot><slot />
     <Footer v-if="footer !== false" />
   </div>
 </template>

--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="app" dark>
     <Header />
-    <slot><slot />
+    <slot></slot>
     <Footer v-if="footer !== false" />
   </div>
 </template>

--- a/src/layouts/Docs.vue
+++ b/src/layouts/Docs.vue
@@ -12,7 +12,7 @@
         </template>
       </div>
       <Section class="doc-content flex-fit" container="base">
-        <slot><slot />
+        <slot></slot>
         <p>
           <a :href="editLink" target="_blank" class="github-edit-link">
             <Github />

--- a/src/layouts/Docs.vue
+++ b/src/layouts/Docs.vue
@@ -12,7 +12,7 @@
         </template>
       </div>
       <Section class="doc-content flex-fit" container="base">
-        <slot />
+        <slot><slot />
         <p>
           <a :href="editLink" target="_blank" class="github-edit-link">
             <Github />


### PR DESCRIPTION
# What
- Add ending tag for `<slot>`

# Why
https://vuejs.org/v2/guide/index.html#Relation-to-Custom-Elements
>That’s because Vue’s component syntax is loosely modeled after the spec.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot
This page explain `slot` Tag omission
>None, both the starting and ending tag are mandatory.


