### PR TITLE
Applying mobile tweaks to iPad portrait resolution

### DIFF
--- a/src/assets/style/utils.scss
+++ b/src/assets/style/utils.scss
@@ -25,7 +25,7 @@
   display: none;
 }
 
-@media screen and (max-width: 750px) {
+@media screen and (max-width: 769px) {
   .hide-for-small {
     display: none!important;
   }


### PR DESCRIPTION
I was viewing the Gridsome.org site on my iPad and it seemed like there were a few display hiccups:

- The top navigation bar was two lines.
- The intro `VueTyper` was overflowing as it typed out, causing the entire page to jerk up and down forever.

In the mobile layout, this is resolved with a line break; this commit just adds those tweaks to the iPad resolution by extending the @media query (intended to show and hide the mobile layout tweaks) just outside the viewport size for iPad. It fixes both the navigation and the typer by doing so.