### PR TITLE
Add more specific details about card.vue file

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -2,7 +2,7 @@
 
 Gridsome uses [Vue Single File Components] (https://vuejs.org/v2/guide/single-file-components.html). This means you add HTML, JavaScript and CSS in the same file. This makes your projects easier to maintain and test and your components more reusable. This is also used for **code-splitting** in the build process.
 
-Here is an example:
+Here’s an example of a file we’ll call `Card.vue` inside `src/components/`:
 
 
 ```html


### PR DESCRIPTION
The docs missing the name of the file (Card.vue) and the location (src/components).

Of course, by the "import" state dev could know this easily - anyway this more clear like this for newbies to vue.