### PR TITLE
templates - add small pre <p> about this issue

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,10 +1,11 @@
 # Templates
+Templates are recurring pieces of content, such as blog posts, help articles, recipes, etc. 
 
 Templates are used for single post views to **GraphQL collections**. Add a **.vue** file with the same name as a GraphQL collection to `src/templates` to create a template. For example, if you have a collection called "**WordPressPost**" you create a **WordPressPost.vue** file.
 
 You can browse available collections in the **schema tab** inside the [GraphQL explorer](/docs/querying-data).
 
-The example shows a **Blog.vue** in **/pages** where Blog posts will be listed and then a **BlogPost.vue** inside **/templates** that will show the single post view.
+The example shows a **Blog.vue** in **/pages** where Blog posts will be listed (Blog page list) and then a **BlogPost.vue** inside **/templates** that will show the single post view.
 
 ![Page structure](./images/dynamic-pages.png)
 


### PR DESCRIPTION
It's better to understand more clearly that the template is for generated content (blog post, articles) - like "post" in the WP world. I don't know what is the exact wording - but like this, it's more clear.