### PR TITLE
deploy - add docs about "how to" add folder to github

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -17,6 +17,8 @@ These services are great for Git-based deploying:
 
 - [GitLab Pages](/docs/deploy-to-gitlab)
 
+Github docs: [ How to add an local folder to GitHub using the command line](https://help.github.com/en/articles/adding-an-existing-project-to-github-using-the-command-line)
+
 ## Deploy from terminal
 Many services let you deploy your static Gridsome site from the terminal. Here are some:
 


### PR DESCRIPTION
This is not 100% related to gridsome docs (devs should know how to use git) - but this is very *short* official docs about this issue - related specifically to deploying. Maybe it will be useful.