### PR TITLE
Big change for template page

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -75,7 +75,6 @@ To include a variable in your template, wrap it in two sets of curly braces. Lik
   {{ $page.post.title }}
 </h1>
  ```
- 
 
 ### Content files
 
@@ -98,7 +97,7 @@ Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula 
 Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem.
 
 ```
-Adding more post entry:
+Add one more post entry:
 
 `/content/posts/my-second-post.md`:
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -122,7 +122,7 @@ Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus
 
 Here is an example of the [file-system source plugin](/plugins/@gridsome/source-filesystem)(We also  [@gridsome/transformer-remark plugin](/plugins/@gridsome/transformer-remark)).
 
-- `typeName` will be the name of the GraphQL collection and needs to be unique. This example will add a *Post* collection.
+- `typeName` - will be the name of the GraphQL collection and needs to be unique. This example will add a *Post* collection.
 - `path` - Where to look for content files. Should be a global path.
 - `route` - Define a dynamic route.
 ```javascript

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -199,4 +199,4 @@ The `<Layout>` component is an optional component used to **wrap pages and templ
 
 - [Query data in Templates](/docs/querying-data#query-data-in-templates)
 - [Add head metadata to Templates](/docs/head#add-head-meta-data-to-pages--templates)
-- [gridsome-starter-blog](https://github.com/gridsome/gridsome-starter-markdown-blog/blob/master/src/pages/Index.vue)
+- [Starter: gridsome-starter-blog](https://github.com/gridsome/gridsome-starter-markdown-blog/blob/master/src/pages/Index.vue)

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -11,6 +11,8 @@ The example shows a **Blog.vue** in **/pages** where Blog posts will be listed a
 
 ## Creating templates
 
+![template flow](https://uploads-ssl.webflow.com/5a0ad22bd65a2f0001be37f0/5cac6ae2efbaefbaae46ed75_template-gridsome.png)
+
 Templates must have a `<page-query>` block which fetches the source node
 for the current page. You can use the `$path` variable to get the node.
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -88,8 +88,6 @@ query postQueryName ($path: String!) {
 
 #### GraphQL Playground
 
-![query example](https://uploads-ssl.webflow.com/5ae579b8e789f452ffdcce17/5cb26238dfaff54e60374e06_query.png)
-
 Every Gridsome project has a GraphQL explorer (Playground) at `http://localhost:8080/___explore`.
 
 **Simple query for title field of Post collection:**
@@ -128,6 +126,7 @@ query Post {
   }
 }
 ```
+![query example](https://uploads-ssl.webflow.com/5ae579b8e789f452ffdcce17/5cb26903dfaff57024376cc4_query-title.png)
 
 [Learn more about Explore & test queries](/docs/layouts)
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -60,7 +60,7 @@ query Post ($path: String!) {
 }
 </page-query>
 
-<style lang="scss">
+<style>
 .post-title {
   padding: calc(var(--space) / 2) 0 calc(var(--space) / 2);
   text-align: center;
@@ -131,6 +131,7 @@ We also added [@gridsome/transformer-remark plugin](/plugins/@gridsome/transform
 
 ```javascript
 module.exports = {
+  siteName: 'Gridsome',
   plugins: [
     {
       use: '@gridsome/source-filesystem',
@@ -139,10 +140,7 @@ module.exports = {
         path: 'content/posts/*.md', /* Where to look for files. Should be a glob path */
         route: '/:slug', /* Define a dynamic route */
       }
-    },
-    {
-      // another data source
-    },
+    }
   ],
   transformers: {
     //Add markdown support to all file-system sources
@@ -151,7 +149,7 @@ module.exports = {
       externalLinksRel: ['nofollow', 'noopener', 'noreferrer'],
       anchorClassName: 'icon icon-link',
       plugins: [
-        '@gridsome/remark-prismjs'
+        // ...local plugins
       ]
     }
   },

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -120,7 +120,7 @@ Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus
 
 ### Linking content to template
 
-Here is an example of the [file-system source plugin](/plugins/@gridsome/source-filesystem)(We also  [@gridsome/transformer-remark plugin](/plugins/@gridsome/transformer-remark).
+Here is an example of the [file-system source plugin](/plugins/@gridsome/source-filesystem)(We also  [@gridsome/transformer-remark plugin](/plugins/@gridsome/transformer-remark)).
 
 - `typeName` will be the name of the GraphQL collection and needs to be unique. This example will add a *Post* collection.
 - `path` - Where to look for content files. Should be a global path.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -98,7 +98,7 @@ Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula 
 Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem.
 
 ```
-Adding more posts entries:
+Adding more post entry:
 
 `/content/posts/my-second-post.md`:
 
@@ -120,23 +120,37 @@ Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus
 
 ### Linking content to template
 
-Here is an example of the [file-system source plugin](/plugins/@gridsome/source-filesystem) added to config (`gridsome.config.js`).
+Here is an example of the [file-system source plugin](/plugins/@gridsome/source-filesystem)(We also  [@gridsome/transformer-remark plugin](/plugins/@gridsome/transformer-remark).
 
+- `typeName` will be the name of the GraphQL collection and needs to be unique. This example will add a *Post* collection.
+- `path` - Where to look for content files. Should be a global path.
+- `route` - Define a dynamic route.
 ```javascript
 module.exports = {
   plugins: [
     {
       use: '@gridsome/source-filesystem',
       options: {
-        typeName: 'Post', /* vue file in src/templates must match the GraphQL typeName to have a template for it.*/
-        path: 'content/posts/*.md', /* Where to look for files. Should be a glob path. */
+        typeName: 'Post', /* vue file in src/templates must match the GraphQL typeName to have a template for it */
+        path: 'content/posts/*.md', /* Where to look for files. Should be a glob path */
         route: '/:slug', /* Define a dynamic route */
       }
     },
     {
       // another data source
     },
-  ]
+  ],
+  transformers: {
+    //Add markdown support to all file-system sources
+    remark: {
+      externalLinksTarget: '_blank',
+      externalLinksRel: ['nofollow', 'noopener', 'noreferrer'],
+      anchorClassName: 'icon icon-link',
+      plugins: [
+        '@gridsome/remark-prismjs'
+      ]
+    }
+  },
 }
 ```
 Learn more about [Use data source plugins](/docs/fetching-data#use-data-source-plugins)

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -141,9 +141,9 @@ module.exports = {
 ```
 Learn more about [Use data source plugins](/docs/fetching-data#use-data-source-plugins)
 
-Save and run `gridsome develop`, the go to `http://localhost:8080/my-first-post` or `http://localhost:8080/my-second-post`.
+Save and run `gridsome develop`, go to `http://localhost:8080/my-first-post` -or- `http://localhost:8080/my-second-post`.
 
-## Create template pagelist
+## Create collection pagelist
 
 `/pages/blog.vue`
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -119,11 +119,14 @@ Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus
 
 ### Linking content to template
 
-Here is an example of the [file-system source plugin](/plugins/@gridsome/source-filesystem)(We also  [@gridsome/transformer-remark plugin](/plugins/@gridsome/transformer-remark)).
+Here is an example of the [file-system source plugin](/plugins/@gridsome/source-filesystem). Plugin options are added to `gridsome.config.js`. 
 
 - `typeName` - will be the name of the GraphQL collection and needs to be unique. This example will add a *Post* collection.
 - `path` - Where to look for content files. Should be a global path.
 - `route` - Define a dynamic route.
+
+We also added [@gridsome/transformer-remark plugin](/plugins/@gridsome/transformer-remark) (Markdown support).
+
 ```javascript
 module.exports = {
   plugins: [

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -122,7 +122,7 @@ Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus
 
 Here is an example of the [file-system source plugin](/plugins/@gridsome/source-filesystem) added to config (`gridsome.config.js`).
 
-```
+```javascript
 module.exports = {
   plugins: [
     {

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -149,14 +149,17 @@ Save and run `gridsome develop`, the go to `http://localhost:8080/my-first-post`
 
 ```html
 <template>
-<Layout>
-  <div class="posts">
-    <li v-for="edge in $page.posts.edges" :key="edge.node.id">
-      <h3>{{ edge.node.title }}</h3>
-      <p>{{ edge.node.description }}</p>
-    </li>
-  </div>
-</Layout>
+  <Layout>
+    <!-- List posts -->
+    <ul class="posts">
+      <li v-for="edge in $page.posts.edges" :key="edge.node.id">
+        <article>
+          <h3>{{ edge.node.title }}</h3>
+          <p>{{ edge.node.description }}</p>
+        </article>
+      </li>
+    </ul>
+  </Layout>
 </template>
 
 <page-query>

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -84,12 +84,16 @@ query postQueryName ($path: String!) {
 ```
 - `post: post` - The post is the name of the GraphQL collection you want to query (Define under `config.js` `typeName: Post`). 
 
-[How to query with GraphQL](/docs/querying-data#how-to-query-with-graphql)_
+[How to query with GraphQL](/docs/querying-data#how-to-query-with-graphql)
 
-#### Playground
+#### GraphQL Playground
+
+![query example](https://uploads-ssl.webflow.com/5ae579b8e789f452ffdcce17/5cb26238dfaff54e60374e06_query.png)
+
 Every Gridsome project has a GraphQL explorer (Playground) at `http://localhost:8080/___explore`.
 
-Example of title query:
+**Simple query for title field of Post collection:**
+
 ```graphql
 query Post {
   allPost {
@@ -102,7 +106,28 @@ query Post {
 }
 
 ```
-![Example query](https://uploads-ssl.webflow.com/5ae579b8e789f452ffdcce17/5cb1fd8e46fa44184fbdacce_query-data.png)
+**Result:**
+
+```graphql
+{
+  "data": {
+    "allPost": {
+      "edges": [
+        {
+          "node": {
+            "title": "My Second post"
+          }
+        },
+        {
+          "node": {
+            "title": "My First post"
+          }
+        }
+      ]
+    }
+  }
+}
+```
 
 [Learn more about Explore & test queries](/docs/layouts)
 
@@ -115,7 +140,6 @@ To include a variable in your template, wrap it in two sets of curly braces. Lik
   {{ $page.post.title }}
 </h1>
  ```
-
 
 ### Content files
 
@@ -138,7 +162,7 @@ Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula 
 Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem.
 
 ```
-Add one more post entry:
+One more post entry:
 
 `/content/posts/my-second-post.md`:
 
@@ -160,13 +184,19 @@ Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus
 
 ### Linking content to template
 
-Here is an example of the [file-system source plugin](/plugins/@gridsome/source-filesystem). Plugin options are added to `gridsome.config.js`. 
+In this example we use [file-system source plugin](/plugins/@gridsome/source-filesystem) and [@gridsome/transformer-remark plugin](/plugins/@gridsome/transformer-remark) (Markdown support).
+
+**Install:**
+- `yarn add @gridsome/source-filesystem`
+- `yarn add @gridsome/transformer-remark`
+
+**Config**
+
+Plugin options are added to `gridsome.config.js`. 
 
 - `typeName` - will be the name of the GraphQL collection and needs to be unique. This example will add a *Post* collection.
 - `path` - Where to look for content files. Should be a global path.
 - `route` - Define a dynamic route.
-
-We also added [@gridsome/transformer-remark plugin](/plugins/@gridsome/transformer-remark) (Markdown support).
 
 ```javascript
 module.exports = {
@@ -194,7 +224,6 @@ module.exports = {
   },
 }
 ```
-Learn more about [Use data source plugins](/docs/fetching-data#use-data-source-plugins)
 
 Save and run `gridsome develop`, go to `http://localhost:8080/my-first-post` -or- `http://localhost:8080/my-second-post`.
 
@@ -207,12 +236,15 @@ Save and run `gridsome develop`, go to `http://localhost:8080/my-first-post` -or
 ```html
 <template>
   <Layout>
+    <h1>Blog</h1>
     <!-- List posts -->
     <ul class="posts">
       <li v-for="edge in $page.posts.edges" :key="edge.node.id">
         <article>
-          <h3>{{ edge.node.title }}</h3>
+          <h2>{{ edge.node.title }}</h2>
+          <date>{{ edge.node.date }}</date>
           <p>{{ edge.node.description }}</p>
+          <g-link :to="edge.node.path">Read Article</g-link>
         </article>
       </li>
     </ul>
@@ -227,6 +259,7 @@ Save and run `gridsome develop`, go to `http://localhost:8080/my-first-post` -or
           title
           date (format: "D. MMMM YYYY")
           description
+          path
         }
       }
     }
@@ -236,7 +269,7 @@ Save and run `gridsome develop`, go to `http://localhost:8080/my-first-post` -or
 <script>
 export default {
   metaInfo: {
-    title: 'Hello, world!'
+    title: 'Blog'
   }
 }
 </script>

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -13,11 +13,9 @@ The example shows a **Blog.vue** in **/pages** where Blog posts will be listed a
 
 ![template flow](https://uploads-ssl.webflow.com/5a0ad22bd65a2f0001be37f0/5cac6ae2efbaefbaae46ed75_template-gridsome.png)
 
-Templates must have a `<page-query>` block which fetches the source node
-for the current page. You can use the `$path` variable to get the node.
+`src/templates/Post.vue`
 
 ```html
-<!-- src/templates/Post.vue -->
 <template>
   <Layout>
     <article>
@@ -50,7 +48,7 @@ export default {
 </script>
 
 <page-query>
-query Post ($path: String!) {
+query postQueryName ($path: String!) {
   post: post (path: $path) {
     title
     date (format: "D. MMMM YYYY")
@@ -69,6 +67,46 @@ query Post ($path: String!) {
 
 ```
 
+### Query with GraphQL
+Templates must have a `<page-query>` block which fetches the source node for the current page. You can use the `$path` variable to get the node.
+
+``` html
+<page-query>
+query postQueryName ($path: String!) {
+  post: post (path: $path) {
+    title
+    date (format: "D. MMMM YYYY")
+    description
+    content
+  }
+}
+</page-query>
+```
+- `post: post` - The post is the name of the GraphQL collection you want to query (Define under `config.js` `typeName: Post`). 
+
+[How to query with GraphQL](/docs/querying-data#how-to-query-with-graphql)_
+
+#### Playground
+Every Gridsome project has a GraphQL explorer (Playground) at `http://localhost:8080/___explore`.
+
+Example of title query:
+```graphql
+query Post {
+  allPost {
+    edges {
+      node {
+        title
+      }
+    }
+  }
+}
+
+```
+![Example query](https://uploads-ssl.webflow.com/5ae579b8e789f452ffdcce17/5cb1fd8e46fa44184fbdacce_query-data.png)
+
+[Learn more about Explore & test queries](/docs/layouts)
+
+### Render data
 To include a variable in your template, wrap it in two sets of curly braces. Like this:
 
 `src/templates/Post.vue`:
@@ -77,6 +115,7 @@ To include a variable in your template, wrap it in two sets of curly braces. Lik
   {{ $page.post.title }}
 </h1>
  ```
+
 
 ### Content files
 
@@ -211,7 +250,6 @@ The `<Layout>` component is an optional component used to **wrap pages and templ
 ** The page/template layout can be named anything. `<Layout>` is just an example. **
 
 [Learn more about Layouts](/docs/layouts)
-
 
 ### More...
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -159,6 +159,8 @@ Learn more about [Use data source plugins](/docs/fetching-data#use-data-source-p
 
 Save and run `gridsome develop`, go to `http://localhost:8080/my-first-post` -or- `http://localhost:8080/my-second-post`.
 
+![Post Example](https://uploads-ssl.webflow.com/5ae579b8e789f452ffdcce17/5cb1f7474e4584388e04109f_post-example.png)
+
 ## Create collection pagelist
 
 `/pages/blog.vue`

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -14,18 +14,24 @@ The example shows a **Blog.vue** in **/pages** where Blog posts will be listed a
 Templates must have a `<page-query>` block which fetches the source node
 for the current page. You can use the `$path` variable to get the node.
 
+
 ```html
-<!-- src/templates/WordPressPost.vue -->
+<!-- src/templates/Post.vue -->
 
 <template>
-  <Layout :title="$page.post.title">
-    <div v-html="$page.post.content">
-  </Layout>
+  <article>
+    <h1 class="articleTitle">
+       {{ $page.post.title }}
+    </h1>
+    <time datetime="{{ $page.post.date }}">{{ $page.post.date }}</time>
+    <p class="articleDescription"> {{ $page.post.description }}</p>
+    <div class="articleBody" v-html="$page.blogPost.content" />
+  </article>
 </template>
 
 <page-query>
 query Post ($path: String!) {
-  post: wordPressPost (path: $path) {
+  post: post  (path: $path) {
     title
     content
   }
@@ -46,6 +52,84 @@ export default {
 }
 </script>
 ```
+
+### Content files
+
+Here is an example of local `markdown` file named `my-first-post.md` located under `$page/content/posts` folder. 
+We use this folder to store all of our blog posts.
+
+Our posts format: A title, publish date, followed by an description.
+
+`/content/posts/my-first-post.md`:
+
+```md
+---
+title: My First post
+date: 2018-09-15 07:42:34
+description: "Aenean leo ligula, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet."
+---
+
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa.
+
+Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem.
+
+```
+
+`/content/posts/my-second-post.md`:
+
+```md
+---
+title: My Second post
+date: 2018-09-16 07:42:34
+description: "Dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet."
+---
+
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa.
+
+Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem.
+
+```
+
+To include a variable in your template, wrap it in two sets of curly braces. Like this:
+
+Under our template we use our `md` format to output data - For example
+
+`src/templates/Post.vue`:
+```html
+  <h1 class="articleTitle">
+     {{ $page.post.title }}
+  </h1>
+ ```
+ 
+
+- Learn more about [@gridsome/transformer-remark plugin](/plugins/@gridsome/transformer-remark)
+- [Markdown-Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)
+- [V-html](https://vuejs.org/v2/guide/syntax.html#Raw-HTML)
+
+### Linking content to template
+
+Here is an example of the [file-system source plugin](/plugins/@gridsome/source-filesystem) added to config (`gridsome.config.js`).
+We declare the path by `path: 'content/posts/*.md'`
+
+```
+module.exports = {
+  plugins: [
+    {
+      use: '@gridsome/source-filesystem',
+      options: {
+        index: ['README'],
+        path: 'content/posts/*.md',
+        typeName: 'DocPage',
+      }
+    },
+    {
+      // another data source
+    },
+  ]
+}
+```
+Learn more about [Use data source plugins](/docs/fetching-data#use-data-source-plugins)
+
 
 ## Template layouts
 


### PR DESCRIPTION
For now, it was very hard to know "how to" use templates (The docs missing the content files and setting in "one place") + The template was very complex (using https://gridsome.org/docs/layouts#passing-props-to-layouts). 

The main idea is to create a simple "hello world" example before users diving to complex template issues (Like prop, components and so on). 

I am new to gridsome so feel free to change this (anyway it's more clear)