### PR TITLE
Always show search bar in nav when in /docs on mobile

### DIFF
--- a/src/layouts/partials/Header.vue
+++ b/src/layouts/partials/Header.vue
@@ -6,7 +6,7 @@
       <Nav class="flex-fit"/>
 
       <nav class="header-actions flex">
-        <SearchForm class="hide-for-small"/>
+        <SearchForm v-bind:class="{ 'hide-for-small': !currentlyInsideDocs }"/>
 
         <a
           aria-label="Twitter"
@@ -14,6 +14,7 @@
           rel="noopener noreferrer"
           target="_blank"
           title="Follow us on Twitter"
+          v-bind:class="{ 'hide-for-small': currentlyInsideDocs }"
         >
           <twitter-logo/>
         </a>
@@ -24,6 +25,7 @@
           rel="noopener noreferrer"
           target="_blank"
           title="Join our discord"
+          v-bind:class="{ 'hide-for-small': currentlyInsideDocs }"
         >
           <discord-logo/>
         </a>
@@ -34,6 +36,7 @@
           rel="noopener noreferrer"
           target="_blank"
           title="Gridsome @ GitHub"
+          v-bind:class="{ 'hide-for-small': currentlyInsideDocs }"
         >
           <github-logo
             height="20px"
@@ -66,6 +69,11 @@ import TwitterLogo from '@/assets/images/twitter-logo.svg'
 import DiscordLogo from '@/assets/images/discord-logo.svg'
 
 export default {
+  computed: {
+    currentlyInsideDocs() {
+      return this.$route.path.startsWith("/docs")
+    },
+  },
   components: {
     Logo,
     GithubLogo,
@@ -102,6 +110,9 @@ header {
   .header-actions {
     margin-left: auto !important;
     font-size: 0.9rem;
+  }
+  .algolia-autocomplete .ds-dropdown-menu {
+    min-width: calc(100vw - 60px);
   }
 }
 </style>


### PR DESCRIPTION
Lets you search docs on much narrower screens (portrait), if the current path starts with "/docs". 

With this it's easier to type and see the immediate results at once in portrait mode - At present the only way to see search box is in landscape, it's hard because on mobiles the onscreen keyboard and header takes up all the visual area.

Outside of /docs this reverts to normal behaviour to show the external social links icons if screen is small and hides the search bar. 

Agolia search automatically adjusts the ltr/rtl direction based on screen size and current input position at render. Results seems to fit fine on the few screen devices I tried with the slight alteration to tie search results min-width to screen size.