### PR TITLE
Remove ligatures from HTML code blocks

### DIFF
--- a/src/assets/style/code.scss
+++ b/src/assets/style/code.scss
@@ -39,6 +39,11 @@
   overflow-x: auto;
 }
 
+// HTML code blocks
+#app pre.language-html {
+  font-variant-ligatures: none;
+}
+
 // inline code
 #app code {
   padding: 0.2em 0.5em;


### PR DESCRIPTION
The ligatures of the `Space Mono` font make HTML code blocks look somewhere between silly and weird. This PR disables font ligatures, at least for HTML code blocks.

![Screenshot of HTML code block from Gridsome home page with enabled font ligatures](https://user-images.githubusercontent.com/1922624/55956688-d0bc5800-5c64-11e9-847a-3b10cc3a1b10.png)
*Screenshot of HTML code block from Gridsome home page*

**EDIT:** This is how the code block looks with the proposed changes:
![Screenshot of HTML code block from Gridsome home page with disabled font ligatures](https://user-images.githubusercontent.com/1922624/55956787-111bd600-5c65-11e9-84cb-e2a8619214ce.png)
