### PR TITLE
Import Font Awesome css to prevent a flash of large icon

### DIFF
--- a/docs/assets-svg.md
+++ b/docs/assets-svg.md
@@ -48,9 +48,11 @@ When the packages have finished installing, you'll want to open (or create) the 
 
 ```js
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { library } from '@fortawesome/fontawesome-svg-core'
+import { config, library } from '@fortawesome/fontawesome-svg-core'
 import { faGithub, faTwitter } from '@fortawesome/free-brands-svg-icons'
+import '@fortawesome/fontawesome-svg-core/styles.css'
 
+config.autoAddCss = false;
 library.add(faGithub, faTwitter)
 
 export default function (Vue) {


### PR DESCRIPTION
Otherwise, font awesome injects the style into the header with JS on load.

This is related to: https://github.com/FortAwesome/vue-fontawesome/issues/14
vue-fontawesome readme contains instructions for resolving this with nuxt.js: https://github.com/FortAwesome/vue-fontawesome#nuxtjs

Is there a better way to import the css file and get it compiled in or is this the best way?  I couldn't find any css array in gridsome like the config for nuxt.js.