### PR TITLE
Add example of how to add JS before body

### DIFF
--- a/docs/head.md
+++ b/docs/head.md
@@ -20,6 +20,12 @@ export default function (Vue, { head }) {
     rel: 'stylesheet',
     href: 'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css'
   })
+  
+  // Add an external Javascript before the closing </body> tag
+  head.script.push({
+    src: 'https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js',
+    body: true
+  })
 
   // Add a meta tag
   head.meta.push({


### PR DESCRIPTION
Very useful to add scripts before the body (For bootstrap js and so on). 

Since nuxt.js v1.0.0
https://github.com/nuxt/nuxt.js/releases/tag/v1.0.0

You can set body: true, in your head.script[] to move your scripts at the end of <body> (see example)

https://github.com/nuxt/nuxt.js/blob/dev/examples/meta-info/pages/index.vue#L18