### PR TITLE
Add custom field of any data type

### DIFF
--- a/docs/data-store-api.md
+++ b/docs/data-store-api.md
@@ -182,7 +182,15 @@ api.loadSource(store => {
 
   contentType.addNode({
     title: 'Lorem ipsum dolor sit amet.',
-    customField: '...'
+    // Custom field of any data type
+    fields: {
+      name: "...",
+      user: {
+        user_id: 12345,
+        user_image: []
+      },
+      verified: false
+    },
   })
 })
 ```


### PR DESCRIPTION
In the current example, it is not clear that what type of custom node fields can be added to `gridsome.server.js` file 

![image](https://user-images.githubusercontent.com/29014463/57585669-cbbf2280-7508-11e9-882d-dea5a2c3d45e.png)

Also `customField: '...'` is not really a not example to use here, since it doesn't work.

