### PR TITLE
Update to routing doc

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -55,7 +55,7 @@ module.exports = function (api) {
     const { data } = await axios.get('https://api.example.com/posts')
 
     const contentType = store.addContentType({
-      typeName: 'BlogPosts'
+      typeName: 'BlogPosts',
       route: 'blog/:slug'  // add this for one dynamic route...
     })
 


### PR DESCRIPTION
There was a missing comma at the end of the `typeName: 'BlogPosts'` line