### PR TITLE
(Guides) Add module path to NetlifyCMS plugin options

### DIFF
--- a/docs/guide-netlify-cms.md
+++ b/docs/guide-netlify-cms.md
@@ -53,7 +53,8 @@ module.exports = {
     {
       use: `gridsome-plugin-netlify-cms`,
       options: {
-        publicPath: `/admin`
+        publicPath: `/admin`,
+        modulePath: `src/admin/index.js`
       }
     },
   ]


### PR DESCRIPTION
Added `modulePath: 'src/admin/index.js'` to the NetlifyCMS plugin options so that the plugin will actually use the `src/admin/index.js` file that is created later.

Without this changes in `index.js` have no effect as it is not included in the build.