### PR TITLE
Fix/table contents links

### DIFF
--- a/docs/deploy-to-google.md
+++ b/docs/deploy-to-google.md
@@ -48,6 +48,6 @@ args: ["-m", "rsync", "-r", "-c", "-d", "./dist", "gs://bucket-name"]
 
 Last build step is to push static files to your bucket
 
-## link dns record to reserved external google ip
+## Link dns record to reserved external google ip
 You must link these to resolve your domain to our external google ip adress.
 This can be done in your DNS service

--- a/docs/deploy-to-google.md
+++ b/docs/deploy-to-google.md
@@ -11,7 +11,7 @@ Please Follow this [tutorial](https://cloud.google.com/storage/docs/hosting-stat
 The HTTPS configuration is a bit more complex.
 
 # Steps to complete
-## 1. Use a Cloud Storage bucket as a load balancer backend
+## Use a Cloud Storage bucket as a load balancer backend
  Steps:
  
       1. Configure a Cloud Storage bucket
@@ -20,17 +20,17 @@ The HTTPS configuration is a bit more complex.
 
 Please follow the steps in the well documented google  [tutorial](https://cloud.google.com/load-balancing/docs/https/adding-a-backend-bucket-to-content-based-load-balancing)
 
-## 2. Set main and error page for bucket
+## Set main and error page for bucket
 gsutil web set -m index.html -e 404.html gs://your-bucket-name
 [Documentation](https://cloud.google.com/storage/docs/gsutil/commands/web)
 
 
 
 # Google cloud build
-## 1. Setup google Source Repositories 
+## Setup google Source Repositories 
 [Documentation](https://cloud.google.com/source-repositories/docs/)
 
-## 2. Add Build trigger
+## Add Build trigger
 Create a new [trigger](https://console.cloud.google.com/cloud-build/triggers)
 
 
@@ -48,6 +48,6 @@ args: ["-m", "rsync", "-r", "-c", "-d", "./dist", "gs://bucket-name"]
 
 Last build step is to push static files to your bucket
 
-## 3. link dns record to reserved external google ip
+## link dns record to reserved external google ip
 You must link these to resolve your domain to our external google ip adress.
 This can be done in your DNS service

--- a/docs/guide-netlify-cms.md
+++ b/docs/guide-netlify-cms.md
@@ -6,20 +6,20 @@ We assume you've worked with `@gridsome/source-filesystem` and `@gridsome/transf
 
 Gridsome requires **Node.js** and recommends **Yarn**. [How to setup](https://gridsome.org/docs/prerequisites)
 
-## 1. Create a Gridsome project
+## Create a Gridsome project
 
 1. `gridsome create my-gridsome-site` to create a new project
 2. `cd my-gridsome-site` to open folder
 3. `gridsome develop` to start local development server
 
-## 2. Install the required dependencies
+## Install the required dependencies
 
 Gridsome already provides you a set of [plugins](https://gridsome.org/plugins) to get you started.
 
 - `yarn add netlify-cms gridsome-plugin-netlify-cms @gridsome/source-filesystem @gridsome/transformer-remark` to install the required dependencies
 - `npm add netlify-cms gridsome-plugin-netlify-cms @gridsome/source-filesystem @gridsome/transformer-remark`
 
-## 3. Configuration
+## Configuration
 
 Alright, the plugins are installed, it's now time to setup the right configuration. Open the `gridsome.config.js` file and make sure it looks like this:
 
@@ -62,7 +62,7 @@ module.exports = {
 
 Please read [gridsome-plugin-netlify-cms](https://gridsome.org/plugins/gridsome-plugin-netlify-cms), [transformer-remark](https://gridsome.org/plugins/@gridsome/transformer-remark) for more information about the configurations.
 
-## 4. Netlify CMS setup
+## Netlify CMS setup
 
 It's time to add the CMS!
 
@@ -125,7 +125,7 @@ backend:
 # The rest of the configuration...
 ```
 
-## 5. Netlify CMS authentication with GitHub
+## Netlify CMS authentication with GitHub
 
 Before we can start adding posts we'll have to give Netlify access to our Github, this part is **crucial**, please follow the steps closely. More info can be read [here](https://www.netlify.com/docs/authentication-providers/);
 
@@ -142,7 +142,7 @@ Part 2, Netlify:
 3. Under Authentication Providers, click Install Provider
 4. Select GitHub and enter the Client ID and Client Secret, then save ([0Auth Docs - How do I find my GitHub client ID and secret?](https://auth0.com/docs/connections/social/github#3-get-your-github-app-s-client-id-and-client-secret))
 
-## 6. Netlify CMS authentication with Bitbucket
+## Netlify CMS authentication with Bitbucket
 
 Another way of integration Netlify CMS could be with the Bitbucket OAuth. Please follow the steps closely. At the moment, there is a lack of support for Editorial Workflow when working with Bitbucket [Bitbucket Editorial Workflow](https://www.netlifycms.org/docs/add-to-your-site/#editorial-workflow);
 


### PR DESCRIPTION
The links for the Netlify CMS and Google Cloud Platform guides weren't working with the numbers in the headings. 
Let me know if there is a better alternative.