### PR TITLE
vue-carousel example - missing installation step Using an external Vue Plugin

### DIFF
--- a/docs/assets-scripts.md
+++ b/docs/assets-scripts.md
@@ -1,18 +1,31 @@
 # Add External Scripts
 It is really easy to use any external javascript with gridsome. Being a Vue based framework any method of importing external scripts in vue works out of the box with Gridsome
 
-## Add to Components
+## Local - Add to Components
 
 ### Using an external Vue Plugin 
 If you want to use external Vue plugins inside your component without defining it globally you can do so by importing it inside your component and registering it for your component.
 
-Example:
+[vue-carousel](https://www.npmjs.com/package/vue-carousel) Example:
+
+Installation
+- Using YARN:  ```npm install vue-carousel```
+- Using NPM:  ```yarn add vue-carousel```
+
+*The rest of this paper omits Installation step.
+
+HTML Structure
+
 ```html
 <template>
-  <Carousel>
-    <Slide />
-    <Slide />
-  </Carousel>
+<carousel :autoplay="true">
+    <slide>
+      Slide 1 Content
+    </slide>
+    <slide>
+      Slide 2 Content
+    </slide>
+  </carousel>
 </template>
 
 <script>

--- a/docs/assets-scripts.md
+++ b/docs/assets-scripts.md
@@ -18,14 +18,14 @@ HTML Structure
 
 ```html
 <template>
-<carousel :autoplay="true">
-    <slide>
-      Slide 1 Content
-    </slide>
-    <slide>
-      Slide 2 Content
-    </slide>
-  </carousel>
+    <carousel :autoplay="true">
+        <slide>
+            Slide 1 Content
+        </slide>
+        <slide>
+            Slide 2 Content
+        </slide>
+    </carousel>
 </template>
 
 <script>


### PR DESCRIPTION
Without installation throw error (vue-carousel)
```
This dependency was not found:
```
Very easy to fix. Anyway, it's more clear/complete like this - to show at least one time "full example"/.

Also, this structure is better (Put content inside the slide)
```
<template>
<carousel :autoplay="true">
    <slide>
      Slide 1 Content
    </slide>
    <slide>
      Slide 2 Content
    </slide>
  </carousel>
</template>
```
And small heading change (Add the word "local") ==> More clear.
 
Also under vue docs (Local Registration VS Global Registration):
https://vuejs.org/v2/guide/components-registration.html#Global-Registration