### PR TITLE
Add svgo options example

### DIFF
--- a/docs/assets-svg.md
+++ b/docs/assets-svg.md
@@ -2,7 +2,7 @@
 One of the easiest ways to use SVGs in Vue and Gridsome is to use the `vue-svg-loader` library. Start by installing the library:
 
 ```js
-npm i -d vue-svg-loader
+npm i -D vue-svg-loader
 ```
 
 You will need to update the webpack config in `gridsome.config.js` to use the new loader:
@@ -16,6 +16,22 @@ module.exports = {
       .loader('vue-svg-loader')
   }
 }
+```
+
+Incase you have to pass [svgo options](https://github.com/svg/svgo "Svgo Readme Page") to the `vue-svg-loader` refer to the following example:
+```js
+chainWebpack: config => {
+    const svgRule = config.module.rule('svg');
+    svgRule.uses.clear();
+    svgRule
+      .use('vue-svg-loader')
+      .loader('vue-svg-loader')
+      .options({
+        svgo: {
+          plugins: [{ removeViewBox: false }] // add options here
+        }
+      });
+  },
 ```
 
 Then you can import your SVGs from within your Vue templates like any normal Vue component:


### PR DESCRIPTION
Recently went through the documentation to add the svg-loader config.

First thing i noticed is, the npm install command was incorrect, maybe a minor typo, since the `-D` parameter has to be uppercase.

The rest of the example was really straightforward, so props for that. I noticed that the loaded svgs were n't scalable anymore, compared to the inline ones I had previously in place. I noticed that the viewbox was removed, which is due to some default of svgo. Took me some digging to find that out. So I thought an example for that would be a great addition to your documentation.