### PR TITLE
Fix broken link under "plugins"

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -67,7 +67,7 @@ module.exports = {
 }
 ```
 
-[Read more about how to use plugins](/docs/plugins/)
+[Read more about how to use plugins](/plugins/)
 
 ## templates
 


### PR DESCRIPTION
changes path from "/docs/plugins/" TO> "/plugins/