### PR TITLE
docs: fix grammatical errors and typos

### DIFF
--- a/blog/2019-09-17-gridsome-07/index.md
+++ b/blog/2019-09-17-gridsome-07/index.md
@@ -165,7 +165,7 @@ Dynamic routing is perfect to use if you need routes for, for example, user acco
 
 #### File-based dynamic routes
 
-Dynamic pages is used for client-side routing. Route parameters can be placed in file and directory names by wrapping the name in square brackets. For example:
+Dynamic pages are used for client-side routing. Route parameters can be placed in file and directory names by wrapping the name in square brackets. For example:
 
 - `src/pages/user/[id].vue` becomes `/user/:id`.
 - `src/pages/user/[id]/settings.vue` becomes `/user/:id/settings`.

--- a/docs/assets-css.md
+++ b/docs/assets-css.md
@@ -34,7 +34,7 @@ You can also use SASS in **Vue Components** with the `lang="scss"` attribute:
 [Learn more about using Using Pre-Processors in Vue.js](https://vue-loader.vuejs.org/guide/pre-processors.html)
 
 ### Global Preprocessor Files (ie. variables, mixins)
-Often when you're working a project, you'll have a set of variables, mixins, and framework variable overrides that you'll want to be automatically used in your components/layouts so you don't have to keep manually importing them.
+Often when you're working on a project, you'll have a set of variables, mixins, and framework variable overrides that you'll want to be automatically used in your components/layouts so you don't have to keep manually importing them.
 
 Start by installing `style-resources-loader`:
 
@@ -108,7 +108,7 @@ In Vue Components you add styles inside a `<style>` tag.
 
 ## Scoped styles in Components
 
-Its very easy to add scoped styles in vue. Simple add "scoped" to the style tag to automatically add suffix to any CSS class in Markup. This means that styles here will only be applied to current component regardless of the class names you use.
+It's very easy to add scoped styles in vue. Simple add "scoped" to the style tag to automatically add suffix to any CSS class in Markup. This means that styles here will only be applied to current component regardless of the class names you use.
 
 ```html
 <style scoped>

--- a/docs/assets-fonts.md
+++ b/docs/assets-fonts.md
@@ -19,7 +19,7 @@ Self-hosting open source fonts, as explained [in the docs](https://github.com/Ky
 - Self-hosting is significantly faster. Loading a typeface from Google Fonts or other hosted font service adds an extra (blocking) network request. In my testing, I’ve found replacing Google Fonts with a self-hosted font can improve a site’s speedindex by ~300 milliseconds on desktop and 1+ seconds on 3g. This is a big deal.
 - Your fonts load offline. It’s annoying to start working on a web project on the train or airplane and see your interface screwed up because you can’t access Google fonts. I remember once being in this situation and doing everything possible to avoid reloading a project as I knew I’d lose the fonts and be forced to stop working.
 - Go beyond Google Fonts. Some of my favorite typefaces aren’t on Google Fonts like Clear Sans, Cooper Hewitt, and Aleo.
-- All web(site|app) dependencies should be managed through NPM whenever possible. Tis the modern way.
+- All web(site|app) dependencies should be managed through NPM whenever possible. This the modern way.
 
 The Typefaces project has already taken care of scripting all of the Google Fonts and Font Squirrel collections into NPM packages. You can see all of the fonts available [in the repo](https://github.com/KyleAMathews/typefaces).
 

--- a/docs/assets-scripts.md
+++ b/docs/assets-scripts.md
@@ -1,5 +1,5 @@
 # Add External Scripts
-It is really easy to use any external javascript with gridsome. Being a Vue based framework any method of importing external scripts in vue works out of the box with Gridsome
+It is really easy to use any external javascript with Gridsome. Being a Vue based framework any method of importing external scripts in vue works out of the box with Gridsome
 
 ## Add to Components
 
@@ -119,7 +119,7 @@ this.$http.get('/'); // TypeError: this.$http.get is not a function
 ```
 Instead, our read-only instance method protects our library, and if you attempt to overwrite it you will get "TypeError: Cannot assign to read only property".
 
-So you can proxy your library to VuePrototype using Object.defineProperty in following way:
+So you can proxy your library to VuePrototype using Object.defineProperty in the following way:
 ```javascript
 //src/main.js
 
@@ -139,7 +139,7 @@ export default function (Vue) {
 ```
 
 ## Without SSR support
-While `gridsome build` gridsome uses server side rendering to create a fully rendered page. So if your Vue component does not support SSR or your external library like `jquery` changes the dom element it won't be rendered properly. For these type of component we suggest you to bind the component inside `<ClientOnly></ClientOnly>` tag and import library inside vue's `mounted()` function.
+While `gridsome build` gridsome uses server side rendering to create a fully rendered page. So if your Vue component does not support SSR or your external library like `jquery` changes the `DOM` element it won't be rendered properly. For these type of component we suggest you to bind the component inside `<ClientOnly></ClientOnly>` tag and import library inside vue's `mounted()` function.
 For Example to use `Vue-carousel` that does not yet support SSR you can do the following
 ```html
 <template>

--- a/docs/body-html-attributes.md
+++ b/docs/body-html-attributes.md
@@ -2,7 +2,7 @@
 Gridsome can use [vue-meta](https://github.com/declandewet/vue-meta) to modify `<body>` and `<head>` attributes.
 
 ## Change attributes globally
-Global body or head attributes is added in `src/main.js`.
+Global body or head attributes are added in `src/main.js`.
 
 ```js
 export default function (Vue, { head }) {
@@ -16,7 +16,7 @@ export default function (Vue, { head }) {
 
 
 ## Change attributes per page
-Custom attributes per page is added inside **.vue components**.
+Custom attributes per page are added inside **.vue components**.
 For example, `src/pages/About.vue` would look something like this:
 
 ```js

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -79,6 +79,6 @@ Read more about how to [query nodes in GraphQL](/docs/querying-data/).
 
 ## Templates for collections
 
-[Templates](/docs/templates/) are used to create single pages for **nodes** in a collection. Nodes needs a corresponding page in order to be presented on its own URL.
+[Templates](/docs/templates/) are used to create single pages for **nodes** in a collection. Nodes need a corresponding page in order to be presented on its own URL.
 
 [Learn more here](/docs/templates/)

--- a/docs/dynamic-routing.md
+++ b/docs/dynamic-routing.md
@@ -4,7 +4,7 @@
 
 ## File-based dynamic routes
 
-Dynamic pages is used for client-side routing. Route parameters can be placed in file and directory names by wrapping the name in square brackets. For example:
+Dynamic pages are used for client-side routing. Route parameters can be placed in file and directory names by wrapping the name in square brackets. For example:
 
 - `src/pages/user/[id].vue` becomes `/user/:id`.
 - `src/pages/user/[id]/settings.vue` becomes `/user/:id/settings`.
@@ -13,7 +13,7 @@ At build time, this will generate `user/_id.html` and `user/_id/settings.html` a
 
 Pages with dynamic routes have lower priority than fixed routes. For example, if you have a `/user/create` and a `/user/:id` route, the `/user/create` route will be prioritized.
 
-Here is a basic page component that uses the `id` prameter from the route to fetch user information client-side:
+Here is a basic page component that uses the `id` parameter from the route to fetch user information on client-side:
 
 ```html
 <template>

--- a/docs/gridsome-cli.md
+++ b/docs/gridsome-cli.md
@@ -1,6 +1,6 @@
 # Gridsome CLI
 
-A command line tool for creating new Gridsome projects. Install Gridsome CLI
+A command-line tool for creating new Gridsome projects. Install Gridsome CLI
 globally with `npm install --global @gridsome/cli`.
 
 ## create

--- a/docs/guide-comments.md
+++ b/docs/guide-comments.md
@@ -1,6 +1,6 @@
 # Add comments to Gridsome
 
-Adding comments to a static site can be easy, you have the option to use either external services that loads an iframe into your site or applications that connects to your Github repository that commits the changes made on your site. We have listed some great services that integrates well with Gridsome.
+Adding comments to a static site can be easy, you have the option to use either external services that loads an iframe into your site or applications that connects to your Github repository that commits the changes made on your site. We have listed some great services that integrate well with Gridsome.
 
 ## Disqus
 Disqus is an external service that injects an iframe on your site, one easy way to use Disqus with Gridsome is to use the package [vue-disqus](https://github.com/ktquez/vue-disqus) that provides you with a custom component that you can use across your project.

--- a/docs/guide-forms.md
+++ b/docs/guide-forms.md
@@ -1,6 +1,6 @@
 # Add a form to Gridsome
 
-Adding forms to a static site is easy, but you need to use an external service. We have listed some great services that integrates well with Gridsome.
+Adding forms to a static site is easy, but you need to use an external service. We have listed some great services that integrate well with Gridsome.
 
 
 ## Formspree

--- a/docs/linking.md
+++ b/docs/linking.md
@@ -16,7 +16,7 @@ The following example links to the `src/pages/About.vue` page:
 <g-link to="/about/">About us</g-link>
 ```
 
-Always add a trailing slash when linking to other internal pages. Because the HTML file for the page is a `index.html` file in a directory. Paths generated for nodes already includes a trailing slash.
+Always add a trailing slash when linking to other internal pages. Because the HTML file for the page is a `index.html` file in a directory. Paths generated for nodes already include a trailing slash.
 
 You do not need to include the [`pathPrefix`](/docs/config#pathprefix) option in the `<g-link>` path.
 

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -48,7 +48,7 @@ module.exports = function (api) {
 
 ## Dynamic routing
 
-Pages can have dynamic routes. Dynamic routes are useful for pages that only need client-side routing. For example user pages that fetches info from an external API in production based on a segment in the URL.
+Pages can have dynamic routes. Dynamic routes are useful for pages that only need client-side routing. For example user pages that fetch info from an external API in production based on a segment in the URL.
 
 Learn more about [dynamic routing](/docs/dynamic-routing/)
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -9,7 +9,7 @@ Visit the [Node.js site](https://nodejs.org/) and follow the instructions to dow
 
 
 Open up your terminal.
-- Run `node --version`. (If you’re new to the command line, “run command” means “type node --version in the command prompt, and hit the Enter key”. From here on, this is what we mean by “run command”).
+- Run `node --version`. (If you’re new to the command-line, “run command” means “type node --version in the command prompt, and hit the Enter key”. From here on, this is what we mean by “run command”).
 - Run `npm --version`.
 - **The output of each of those commands should be a version number**. If entering those commands doesn’t show you a version number, go back and make sure you have installed **Node.js**.
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,6 +1,6 @@
 # Templates
 
-> Templates are used to create single pages for nodes in a [collection](/docs/collections/). Nodes needs a corresponding page in order to be presented on its own URL.
+> Templates are used to create single pages for nodes in a [collection](/docs/collections/). Nodes need a corresponding page in order to be presented on its own URL.
 
 
 ## Setup templates

--- a/learn/dev-setup.md
+++ b/learn/dev-setup.md
@@ -2,7 +2,7 @@
 
 ## Overview of core tech
 
-## The command line
+## The command-line
 
 ## Install node.js
 Download and install from [NodeJS.org](https://nodejs.org/)


### PR DESCRIPTION
Here's what this PR contains:
- [x] Fix typos
- [x] Fix grammatical errors
- [x] Reformorted text

I was just going through `Gridsome.org` docs and saw some typos, it took me 2 hrs to read docs partially. There are multiple things that need to be fixed e.g. Explanation, Code snippets, etc. In the future, I would give it another shot to improve docs.