### PR TITLE
update docs: fix typos and reformat

### DIFF
--- a/blog/2018-10-10-say-hello-to-gridsome/index.md
+++ b/blog/2018-10-10-say-hello-to-gridsome/index.md
@@ -50,7 +50,7 @@ The GraphQL layer and all the data can be explored in a local GraphQL playground
 
 #### Perfect scores on Google Lighthouse - automagically 💚
 
-One of the main goals of Gridsome is to make a framework that let you build websites that are optimized "out-of-the-box." It follows the [PRPL-pattern by Google.](https://developers.google.com/web/fundamentals/performance/prpl-pattern/) You don't need to be a performance expert to make fast websites with Gridsome. Your site gets almost perfect scores on Google lighthouse out-of-the-box. These are some of the performance steps that Gridsome takes care of:
+One of the main goals of Gridsome is to make a framework that lets you build websites that are optimized "out-of-the-box." It follows the [PRPL-pattern by Google.](https://developers.google.com/web/fundamentals/performance/prpl-pattern/) You don't need to be a performance expert to make fast websites with Gridsome. Your site gets almost perfect scores on Google lighthouse out-of-the-box. These are some of the performance steps that Gridsome takes care of:
 
 - Image compressing & lazy-loading ⚡️ 
 - CSS & JS minification ⚡️ 

--- a/blog/2019-02-19-gridsome-05/index.md
+++ b/blog/2019-02-19-gridsome-05/index.md
@@ -60,7 +60,7 @@ The [Plugins](/plugins/) page now gets plugins from NPM directory. Any plugin wi
 There are no breaking API changes, but some changes might have consequences:
 
 - External image URLs has previously been converted to objects. Which required you to get the actual URL in a `imageField.src` property. But those fields are no longer converted to objects.
-- Filepaths in front matter or markdown must start with `./` or `../` to be resolved and processed. Which means `image.png` will not be processed, but `./image.png` will be.
+- Filepaths in front matter or markdown must start with `./` or `../` to be resolved and processed which means `image.png` will not be processed, but `./image.png` will be.
 
 
 ## What's next

--- a/blog/2019-05-10-gridsome-06/index.md
+++ b/blog/2019-05-10-gridsome-06/index.md
@@ -3,7 +3,7 @@ title: Gridsome v0.6
 slug: gridsome-v06
 author: [hjvedvik, tommyvedvik]
 date: 2019-05-10
-excerpt: "Gridsome 0.6 introduces a Pages API that gives you full control of page creation. It also has an API that let you fetch internal pages into other pages and components. This is perfect for lightboxes or «Click for more» pagination etc. 0.6 also improves build times and has a smaller core JS bundle size!"
+excerpt: "Gridsome 0.6 introduces a Pages API that gives you full control of page creation. It also has an API that lets you fetch internal pages into other pages and components. This is perfect for lightboxes or «Click for more» pagination etc. 0.6 also improves build times and has a smaller core JS bundle size!"
 ---
 
 💥 *This version includes breaking changes.*
@@ -93,7 +93,7 @@ Add data by using `$context` in Vue component.
 Read more about the [Pages API](/docs/pages-api/)
 
 ## New function for fetching internal pages
-A new function available in [Client API](/docs/client-api/) let you fetch internal pages. This is perfect for building lightboxes or «Click for more» pagination etc.
+A new function available in [Client API](/docs/client-api/) lets you fetch internal pages. This is perfect for building lightboxes or «Click for more» pagination etc.
 
 ```js
 export default {
@@ -118,7 +118,7 @@ Learn more about [fetching internal pages](/docs/client-side-data/)
 
 ## Faster build times and smaller core JS bundle size
 
-Gridsome has been importing `page-query` data with webpack dynamic imports. Which means that webpack had to compile every JSON file into a JavaScript chunk. Having lots of pages would increase build times unnecessary. From now on, page data will be stored as raw JSON files without interference from webpack. And each file is prefetched and loaded on demand for each page. The overall JavaScript size is reduced by about 30% in most cases.
+Gridsome has been importing `page-query` data with webpack dynamic imports which means that webpack had to compile every JSON file into a JavaScript chunk. Having lots of pages would increase build times unnecessary. From now on, page data will be stored as raw JSON files without interference from webpack. And each file is prefetched and loaded on demand for each page. The overall JavaScript size is reduced by about 30% in most cases.
 
 **Example when building a site with 8300 pages:**
 

--- a/blog/2019-09-17-gridsome-07/index.md
+++ b/blog/2019-09-17-gridsome-07/index.md
@@ -17,7 +17,7 @@ excerpt: "Version 0.7 is finally here! Enjoy Vue Components in Markdown, new Sch
 
 ## Vue Remark plugin
 
-With Gridsome 0.7 follows a new plugin called [@gridsome/vue-remark](/plugins/@gridsome/vue-remark). It let you add Vue Components to Markdown files. This is perfect for Documentation, Design Systems, or portfolio websites. It's an Vue / Gridsome alternative to [MDX](https://mdxjs.com/).
+With Gridsome 0.7 follows a new plugin called [@gridsome/vue-remark](/plugins/@gridsome/vue-remark). It lets you add Vue Components to Markdown files. This is perfect for Documentation, Design Systems, or portfolio websites. It's an Vue / Gridsome alternative to [MDX](https://mdxjs.com/).
 
 
 Here is a quick overview of how it works:
@@ -191,7 +191,7 @@ module.exports = function (api) {
 
 ## Custom App.vue
 
-**App.vue** is the file that wraps your whole website or app. Gridsome usually adds a `App.vue` automatic in the background. This can now be overridden by having your own `App.vue` file in your `src` directory. Overriding it is useful if you want to have a **layout that is shared across all your pages.** Or if you want to have a `<transition>` component around the `<router-view>`.
+**App.vue** is the file that wraps your whole website or app. Gridsome usually adds a `App.vue` automatic in the background. This can now be overridden by having your own `App.vue` file in your `src` directory. Overriding `App.vue` is useful if you want to have a **layout that is shared across all your pages.** Or if you want to have a `<transition>` component around the `<router-view>`.
 
 Here is an example:
 

--- a/blog/2019-10-08-integrate-infinite-loading/index.md
+++ b/blog/2019-10-08-integrate-infinite-loading/index.md
@@ -17,7 +17,7 @@ You can check out a full working example here: https://gridsome-infinite-loading
 
 ## Install the required dependencies
 
-There are many packages that implement the infinite loading technique but one that works particularly well with Gridsome is [vue-infinite-loading](https://github.com//PeachScript/vue-infinite-loading). To add it to your gridsome project, `cd` into your project's root and run the following:
+There are many packages that implement the infinite loading technique but one that works particularly well with Gridsome is [vue-infinite-loading](https://github.com//PeachScript/vue-infinite-loading). To add it to your Gridsome project, `cd` into your project's root and run the following:
 
 `yarn add vue-infinite-loading`
 

--- a/docs/assets-css.md
+++ b/docs/assets-css.md
@@ -367,7 +367,7 @@ npm install webpack-node-externals --save-dev
 yarn add webpack-node-externals --dev
 ```
 
-Then modify your gridsome.server.js file to include the webpack-node-externals package, and whitelist Vuetify.
+Then modify your `gridsome.server.js` file to include the webpack-node-externals package, and whitelist Vuetify.
 ```js
 const nodeExternals = require('webpack-node-externals')
 
@@ -388,5 +388,5 @@ module.exports = function (api) {
 }
 ```
 
-Then you should be able to build now! You will find the files in your dist/ folder.
+Then you should be able to build now! You will find the files in your dist/folder.
 

--- a/docs/assets-fonts.md
+++ b/docs/assets-fonts.md
@@ -16,14 +16,14 @@ export default function (Vue, { head }) {
 ## Self-Hosting Open Source Typefaces
 
 Self-hosting open source fonts, as explained [in the docs](https://github.com/KyleAMathews/typefaces):
-- Self-hosting is significantly faster. Loading a typeface from Google Fonts or other hosted font service adds an extra (blocking) network request. In my testing, I’ve found replacing Google Fonts with a self-hosted font can improve a site’s speedindex by ~300 milliseconds on desktop and 1+ seconds on 3g. This is a big deal.
-- Your fonts load offline. It’s annoying to start working on a web project on the train or airplane and see your interface screwed up because you can’t access Google fonts. I remember once being in this situation and doing everything possible to avoid reloading a project as I knew I’d lose the fonts and be forced to stop working.
-- Go beyond Google Fonts. Some of my favorite typefaces aren’t on Google Fonts like Clear Sans, Cooper Hewitt, and Aleo.
-- All web(site|app) dependencies should be managed through NPM whenever possible. This the modern way.
+- Self-hosting is significantly faster. Loading a typeface from Google Fonts or other hosted font service adds an extra (blocking) network request. While testing, we’ve found replacing Google Fonts with a self-hosted font can improve a site’s speedindex by ~300 milliseconds on desktop and 1+ seconds on 3g. This is a big deal.
+- Your fonts load offline. It’s annoying to start working on a web project on the train or airplane and see your interface screwed up because you can’t access Google Fonts.
+- Go beyond Google Fonts. Some of typefaces aren’t on Google Fonts like Clear Sans, Cooper Hewitt, and Aleo.
+- All web(site|app) dependencies should be managed through NPM whenever possible. This is the modern way.
 
 The Typefaces project has already taken care of scripting all of the Google Fonts and Font Squirrel collections into NPM packages. You can see all of the fonts available [in the repo](https://github.com/KyleAMathews/typefaces).
 
-Once you know what font you want to use, it's just a simple NPM install. For example, if we were going to use Open Sans:
+Once you know what font you want to use, it's just a simple NPM install. For example, if want to use Open Sans:
 
 ```sh
 npm i -d typeface-open-sans

--- a/docs/assets-scripts.md
+++ b/docs/assets-scripts.md
@@ -1,5 +1,5 @@
 # Add External Scripts
-It is really easy to use any external javascript with Gridsome. Being a Vue based framework any method of importing external scripts in vue works out of the box with Gridsome
+It is really easy to use any external javascript with Gridsome. Being a Vue based framework any method of importing external scripts in Vue works out of the box with Gridsome
 
 ## Add to Components
 
@@ -31,7 +31,7 @@ export default {
 ```
 
 ### Using an external library 
-If you want to use a external javascript library inside your component you can do so by importing the component and requiring it once vue components are mounted.
+If you want to use a external javascript library inside your component you can do so by importing the component and requiring it once Vue components are mounted.
 
 Example:
 ```html
@@ -64,7 +64,7 @@ If you want scripts to be globally available you usually add them to `src/main.j
 **Note:** Avoid injecting dependencies globally, and use it only if really necessary. Injecting locally into components is considered a better practice for code splitting.
 
 ### Using an external Vue Plugin 
-To use any external vue plugin with gridsome. Just import the required plugin and pass the required plugin to Vue using the following function `Vue.use` inside your main.js file
+To use any external Vue plugin with Gridsome. Just import the required plugin and pass the required plugin to Vue using the following function `Vue.use` inside your main.js file
 
 Example:
 ```javascript
@@ -82,10 +82,10 @@ export default function (Vue) {
 
 }
 ```
-In this example we are importing `VueTypedJs` plugin inside our gridsome project
+In this example we are importing `VueTypedJs` plugin inside our Gridsome project
 
 ### Using an external library 
-To use any external library on our gridsome project you may  proxy it to a property of the Vue prototype object. Since all components inherit their methods from the Vue prototype object this will make your external automatically available across any and all components with no global variables or anything to manually import.
+To use any external library on our Gridsome project you may proxy it to a property of the Vue prototype object. Since all components inherit their methods from the Vue prototype object this will make your external library or libraries automatically available across any and all components with no global variables or anything to manually import.
 
 Example:
 ```javascript
@@ -139,7 +139,7 @@ export default function (Vue) {
 ```
 
 ## Without SSR support
-While `gridsome build` gridsome uses server side rendering to create a fully rendered page. So if your Vue component does not support SSR or your external library like `jquery` changes the `DOM` element it won't be rendered properly. For these type of component we suggest you to bind the component inside `<ClientOnly></ClientOnly>` tag and import library inside vue's `mounted()` function.
+While `gridsome build` Gridsome uses server side rendering to create a fully rendered page. So if your Vue component does not support SSR or your external library like `jquery` changes the `DOM` element it won't be rendered properly. For these type of components we suggest you to bind the component inside `<ClientOnly></ClientOnly>` tag and import library inside Vue's `mounted()` function.
 For Example to use `Vue-carousel` that does not yet support SSR you can do the following
 ```html
 <template>
@@ -173,7 +173,7 @@ For Example to use `Vue-carousel` that does not yet support SSR you can do the f
   }
 </script>
 ```
-This will stop SSR from rendering the component, and component is displayed after the vue components are mounted.
+This will stop SSR from rendering the component, and component is displayed after the Vue components are mounted.
 
 Same way you can use any external library that causes issue in server side rendering like `jquery`
 

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -76,7 +76,7 @@ Read more about the [Vue router](https://router.vuejs.org/api/#router-instance-m
 
 - Type: `Object`
 
-Allows you to manage your websites's metadata.
+Allows you to manage your websites' metadata.
 
 ```js
 export default function (Vue, { head }) {

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -60,14 +60,14 @@ Learn more about the [Data Store API](/docs/data-store-api/).
 
 ## Collections in GraphQL
 
-Each collection will add two root fields to the [GraphQL schema](/docs/data-layer/) that are used to retrieve nodes in your pages. The field names are auto generated based on the collection name. If you name the collection `Post`, you will have these fields available in the schema:
+Each collection will add two root fields to the [GraphQL schema](/docs/data-layer/) that are used to retrieve nodes in your pages. The field names are auto-generated based on the collection name. If you name the collection `Post`, you will have these fields available in the schema:
 
 - `post` Get a single node by `id`.
 - `allPost` Get a list of nodes. *(Can be sorted and filtered.)*
 
 #### Automatic schema generation
 
-Each collection type in the schema will have fields that are auto generated based on discovered data on startup. That's great for simple projects but will often lead to errors with for example missing fields because content has been removed in an external source. You can use the [Schema API](/docs/schema-api/) to define your own schema that will persist when data changes.
+Each collection type in the schema will have fields that are auto-generated based on discovered data on startup. That's great for simple projects but will often lead to errors with for example missing fields because content has been removed in an external source. You can use the [Schema API](/docs/schema-api/) to define your own schema that will persist when data changes.
 
 *Custom schema types for a collection **must** implement the `Node` interface.*
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,6 +1,6 @@
 # Project configuration
 
-Gridsome requires `gridsome.config.js` to work. Plugin and project settings are located here. A basic configuration file would look something like this:
+Gridsome requires `gridsome.config.js` to work. Plugins and project settings are located here. A basic configuration file would look something like this:
 
 ```js
 module.exports = {
@@ -43,7 +43,7 @@ subdirectory called `my-app`.
 - Default `%s - <siteName>`
 
 Set a template for the title tag. The `%s` placeholder is replaced with title
-from metaInfo you set in your pages.
+from metaInfo that you set in your pages.
 
 ## plugins
 

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -1,7 +1,7 @@
 # Core concepts
 
 ## Pages
-[Pages](/docs/pages/) is created by adding **Vue Components** in `src/pages` folder. It uses a file-based routing system. For example, `src/pages/About.vue` will be `mywebsite.com/about`. Pages are used for simple pages and for pages that list collections (Like a `/blog`)
+[Pages](/docs/pages/) are created by adding **Vue Components** in `src/pages` folder. They use a file-based routing system. For example, `src/pages/About.vue` will be `mywebsite.com/about`. Pages are used for simple pages and for pages that list collections (Like a `/blog`)
 
 [Learn more about Pages](/docs/pages/)
 

--- a/docs/deploy-to-github.md
+++ b/docs/deploy-to-github.md
@@ -41,7 +41,7 @@ GitHub Pages allows you to have a "Github user page" that acts as a profile/main
   ```js
   siteUrl: 'https://www.yourname.com',
   ```
-* If you are using an apex domain for your GitHub user page (ie. `https://yourname.com` points to all of your GitHub Pages sites), and your Gridsome project is *not* your GitHub user page (not on the root `https://yourname.com` page, but a separate repo), then you will need to make sure `pathPrefix` matches your gridsome project's repo name in `gridsome.config.js`:
+* If you are using an apex domain for your GitHub user page (ie. `https://yourname.com` points to all of your GitHub Pages sites), and your Gridsome project is *not* your GitHub user page (not on the root `https://yourname.com` page, but a separate repo), then you will need to make sure `pathPrefix` matches your Gridsome project's repo name in `gridsome.config.js`:
   ```js
   pathPrefix: '/<your-gridsome-repo-name>',
   ```

--- a/docs/deploy-to-google.md
+++ b/docs/deploy-to-google.md
@@ -18,7 +18,7 @@ The HTTPS configuration is a bit more complex.
       2. Configure a load balancing service
       3. Create an external adress
 
-Please follow the steps in the well documented google  [tutorial](https://cloud.google.com/load-balancing/docs/https/adding-a-backend-bucket-to-content-based-load-balancing)
+Please follow the steps in the well documented Google [tutorial](https://cloud.google.com/load-balancing/docs/https/adding-a-backend-bucket-to-content-based-load-balancing)
 
 ## Set main and error page for bucket
 gsutil web set -m index.html -e 404.html gs://your-bucket-name
@@ -27,7 +27,7 @@ gsutil web set -m index.html -e 404.html gs://your-bucket-name
 
 
 # Google cloud build
-## Setup google Source Repositories 
+## Setup Google Source Repositories 
 [Documentation](https://cloud.google.com/source-repositories/docs/)
 
 ## Add Build trigger
@@ -48,6 +48,6 @@ args: ["-m", "rsync", "-r", "-c", "-d", "./dist", "gs://bucket-name"]
 
 Last build step is to push static files to your bucket
 
-## Link dns record to reserved external google ip
-You must link these to resolve your domain to our external google ip adress.
+## Link DNS record to reserved external Google IP
+You must link these to resolve your domain to our external Google IP adress.
 This can be done in your DNS service

--- a/docs/dynamic-routing.md
+++ b/docs/dynamic-routing.md
@@ -1,6 +1,6 @@
 # Dynamic Routing
 
-> Dynamic routes are useful for pages that only need client-side routing. For example pages that fetches info from an external API in production based on a segment in the URL.
+> Dynamic routes are useful for pages that only need client-side routing. For example pages that fetch info from an external API in production based on a segment in the URL.
 
 ## File-based dynamic routes
 
@@ -60,7 +60,7 @@ module.exports = function (api) {
 
 ## Generating rewrite rules
 
-Gridsome is not able to generate HTML files for every possible variation of a dynamic route. Which means the URLs most likely will show a 404 page when visited directly. Instead, Gridsome generates one HTML file which can be used in a rewrite rule. For example, a route like `/user/:id` will generate a HTML file located at `/user/_id.html`. You can have a rewrite rule to map all paths matching `/user/:id` to that file.
+Gridsome is not able to generate HTML files for every possible variation of a dynamic route which means the URLs most likely will show a 404 page when visited directly. Instead, Gridsome generates one HTML file which can be used in a rewrite rule. For example, a route like `/user/:id` will generate a HTML file located at `/user/_id.html`. You can have a rewrite rule to map all paths matching `/user/:id` to that file.
 
 Rewrite rules must be generated manually because every server type has its own syntax. The `redirects` array in the `afterBuild` hook contains all necessary rewrite rules that should be generated.
 

--- a/docs/guide-comments.md
+++ b/docs/guide-comments.md
@@ -1,6 +1,6 @@
 # Add comments to Gridsome
 
-Adding comments to a static site can be easy, you have the option to use either external services that loads an iframe into your site or applications that connects to your Github repository that commits the changes made on your site. We have listed some great services that integrate well with Gridsome.
+Adding comments to a static site can be easy, you have the option to use either external services that load an iframe into your site or applications that connect to your Github repository which commits the changes made on your site. We have listed some great services that integrate well with Gridsome.
 
 ## Disqus
 Disqus is an external service that injects an iframe on your site, one easy way to use Disqus with Gridsome is to use the package [vue-disqus](https://github.com/ktquez/vue-disqus) that provides you with a custom component that you can use across your project.

--- a/docs/guide-forms.md
+++ b/docs/guide-forms.md
@@ -55,7 +55,7 @@ First we will start by adding the form to our template tag:
 </form>
 ```
 
-We have include a honeypot input that will lure bots trying to send spam and Netlify will automatically reject them.
+We have included a honeypot input that will lure bots trying to send spam and Netlify will automatically reject them.
 
 Next step is to add our `formData` variable that will hold our data that will be sent to Netlify, this is bound to our inputs to automatically update `formData` when the input is changed.
 

--- a/docs/guide-netlify-cms.md
+++ b/docs/guide-netlify-cms.md
@@ -133,7 +133,7 @@ Part 1, GitHub:
 
 1. Open [this](https://github.com/settings/developers) link
 2. Click on "New OAuth App"
-3. Fill in all the fields according to your website and use `https://api.netlify.com/auth/done` as Authorization callback URL
+3. Fill in all the fields according to your website and use `https://api.netlify.com/auth/done` as `authorization` callback URL
 
 Part 2, Netlify:
 
@@ -151,10 +151,11 @@ Part 1, Bitbucket:
 1. Open [this](https://bitbucket.org/account/user) link
   1.1 Under **ACCESS MANAGEMENT** find OAuth link, and open it
 2. Scroll to "OAuth consumers" and click on the button "Add consumer"
-3. Fill in all the fields according to your website and use `https://api.netlify.com/auth/done` as Callback URL
+3. Fill in all the fields according to your website and use `https://api.netlify.com/auth/done` as   `authorization` callback URL
 4. Upon creation you will get the Key and Secret which will be used in Netlify
 
 Part 2, Netlify:
+
 1. Go to your Netlify dashboard and click on your project
 2. Navigate to Settings > Access control > OAuth
 3. Under Authentication Providers, click Install Provider
@@ -163,4 +164,4 @@ Part 2, Netlify:
 
 ## Start coding
 
-Your basic blog scaffold is done now, you can now query data from the GraphQL server just like you're working with the filesystem. For more info read [querying data](https://gridsome.org/docs/querying-data).
+Your basic blog scaffold is done, now you can query data from the GraphQL server just like you're working with the filesystem. For more info read [querying data](https://gridsome.org/docs/querying-data).

--- a/docs/how-to-create-a-plugin.md
+++ b/docs/how-to-create-a-plugin.md
@@ -19,13 +19,13 @@ Learn more about the [Data Store API](/docs/data-store-api/)
 
 ## Create a general plugin
 
-Other plugins that adds functionality should be named `gridsome-plugin-*` or `@username/gridsome-plugin-*`.
+Other plugins that add functionality should be named `gridsome-plugin-*` or `@username/gridsome-plugin-*`.
 
 Learn more about the [Server API](/docs/server-api/) or [Client API](/docs/client-api/)
 
 ## Create a transformer
 
-Transformers doesn't work like the plugins above, but they are used by the source plugins to parse content. They can also add more fields to the GraphQL schema. Transformers must be named `gridsome-transformer-*` or `@username/gridsome-transformer-*` in order to be found by the source plugins.
+Transformers don't work like the plugins above, but they are used by the source plugins to parse content. They can also add more fields to the GraphQL schema. Transformers must be named `gridsome-transformer-*` or `@username/gridsome-transformer-*` in order to be found by the source plugins.
 
 Learn more about the [Transformer API](/docs/transformer-api/)
 

--- a/docs/images.md
+++ b/docs/images.md
@@ -74,7 +74,7 @@ Crop the image by settings both `width` and `height` attributes. The image will 
 |fit 			 |`"cover"` |How to crop images. See properties below.
 |background|          |Background color for 'contain'
 |immediate |`false`   |Set to `true` to disable lazy-loading
-|blur      |`40`      	|How much in px to blur the image placeholder
+|blur      |`40`      	|How much in pixels to blur the image placeholder
 |quality   |`75`      |The quality of the image. (`0` - `100`).
 
 ## Fit options

--- a/docs/pages-api.md
+++ b/docs/pages-api.md
@@ -63,7 +63,7 @@ Create a new page.
 
 ### removePage(page)
 
-Removed a page created by `createPage`.
+Removes a page created by `createPage`.
 
 ### removePageByPath(path)
 

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -1,6 +1,6 @@
 # Paginate data
 
-Use the `@paginate` directive in your GraphQL query to add automatic pagination for a list of source nodes. The query will receive a `$page: Int` variable you can use to load sources for a specific page. Default nodes per page is `25`.
+Use the `@paginate` directive in your GraphQL query to add automatic pagination for a list of source nodes. The query will receive a `$page: Int` variable you can use to load sources for a specific page. Default nodes per page are `25`.
 
 ## Paginated collections
 

--- a/docs/querying-data.md
+++ b/docs/querying-data.md
@@ -133,7 +133,7 @@ query Blog {
 
 ## Query data in any component
 
-Every **Vue component** can have a `<static-query>` block with a GraphQL query to fetch data from data sources. The results will be stored in a `$static` property inside the component. A `<static-query>` is named static as it can not accept any variables.
+Every **Vue component** can have a `<static-query>` block with a GraphQL query to fetch data from data sources. The results will be stored in a `$static` property inside the component. A `<static-query>` is named static as it cannot accept any variable.
 
 ```html
 <template>

--- a/docs/schema-api.md
+++ b/docs/schema-api.md
@@ -46,9 +46,9 @@ api.loadSource(({ addSchemaTypes, schema }) => {
 
 - resolvers `object` *Required.*
 
-Resolvers are methods that are executed on each field in the query. The default resolvers for types like `String` or `Int` simply returns the value without any modifications. Resolvers for fields that are referencing another node are interacting with the internal store to return data from the requested node.
+Resolvers are methods that are executed on each field in the query. The default resolvers for types like `String` or `Int` simply return the value without any modifications. Resolvers for fields that are referencing another node are interacting with the internal store to return data from the requested node.
 
-Use the `addSchemaResolvers()` action to add new fields or override existing fields. The resolver method will recieve four arguments that can be used:
+Use the `addSchemaResolvers()` action to add new fields or override existing fields. The resolver method will receive four arguments that can be used:
 
 ```js
 addSchemaResolvers({
@@ -137,7 +137,7 @@ api.loadSource(({ addSchema }) => {
 
 ### @infer
 
-Custom schemas for meta data and collections will not infer any more field types from the source by default. Add the `@infer` extension to add discovered fields that isn't defined in the custom schema.
+Custom schemas for meta data and collections will not infer any more field types from the source by default. Add the `@infer` extension to add discovered fields that aren't defined in the custom schema.
 
 ```graphql
 type Post implements Node @infer {

--- a/examples/create-pages-api.md
+++ b/examples/create-pages-api.md
@@ -5,7 +5,7 @@ filetype: js
 order: 10
 ---
 ```js
-// The Pages API let you create pages without using GraphQL,
+// The Pages API lets you create pages without using GraphQL,
 // and create pages programmatically 
 const axios = require('axios')
 


### PR DESCRIPTION
Here's what this PR contains: 
- [x] fix typos
- [x] capitalize nouns
- [x] reformat text
- [x] align grammar
Now  I can hope `docs` would be `error-free`. It took me 4 hrs today, to re-read all the docs again to fix the issues. @gridsome/core, Thanks for sending invitation to join `Gridsome`.