### PR TITLE
fix: remove query operation name

### DIFF
--- a/blog/2018-10-10-say-hello-to-gridsome/index.md
+++ b/blog/2018-10-10-say-hello-to-gridsome/index.md
@@ -27,7 +27,7 @@ Here is an example on how to query posts from the GraphQL layer in a page:
 </template>
 
 <page-query>
-query Blog {
+query {
   allWordPressPost (limit: 5) {
     edges {
       node {

--- a/blog/2019-09-17-gridsome-07/index.md
+++ b/blog/2019-09-17-gridsome-07/index.md
@@ -58,7 +58,7 @@ By default it takes any **.md** files in `baseDir` folder and uses them for file
 
 <!-- Front-matter fields can be queried from GraphQL layer -->
 <page-query>
-query Documentation ($id: ID!) {
+query ($id: ID!) {
   documentation(id: $id) {
     title
     excerpt

--- a/blog/2019-10-08-integrate-infinite-loading/index.md
+++ b/blog/2019-10-08-integrate-infinite-loading/index.md
@@ -42,7 +42,7 @@ To demonstrate how to use `vue-infinite-loading` let's assume a pretty typical B
 Your paginated `<page-query>` would look something like this:
 
 ```graphql
-query Blog($page: Int) {
+query ($page: Int) {
 	posts: allBlogPost(perPage: 10, page: $page) @paginate {
 		pageInfo {
 			totalPages

--- a/docs/components.md
+++ b/docs/components.md
@@ -74,7 +74,7 @@ to fetch data from data sources. The results will be stored in a
 </template>
 
 <static-query>
-query Post {
+query {
   post (id: "1") {
     content
   }

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -30,7 +30,7 @@ Here is an example:
 </template>
 
 <page-query>
-query Post($id: ID!) {
+query ($id: ID!) {
   post(id: $id) {
     title
   }

--- a/docs/data-store-api.md
+++ b/docs/data-store-api.md
@@ -85,7 +85,7 @@ api.loadSource(({ addCollection, store }) => {
 The field will contain the referenced node fields in the GraphQL schema:
 
 ```graphql
-query BlogPost($id: ID!) {
+query ($id: ID!) {
   blogPost(id: $id) {
     title
     author1 {
@@ -140,7 +140,7 @@ api.loadSource(actions => {
 You will then be able to query that data in the `page-query` and `static-query` tags in your Vue components with a query like this:
 
 ```graphql
-query MyData {
+query {
   allMyData {
     edges {
       node {

--- a/docs/images.md
+++ b/docs/images.md
@@ -41,7 +41,7 @@ Local image paths from sources can also be compressed. Options like `width`, `he
 </template>
 
 <page-query>
-query BlogPost ($id: ID!) {
+query ($id: ID!) {
   post: blogPost (id: $id) {
     image (width: 720, height: 200, quality: 90)
   }

--- a/docs/overriding-app.md
+++ b/docs/overriding-app.md
@@ -14,7 +14,7 @@ The default `App.vue` component inserts the `siteName` and `siteDescription` as 
 </template>
 
 <static-query>
-query App {
+query {
   metadata {
     siteName
     siteDescription

--- a/docs/pages-api.md
+++ b/docs/pages-api.md
@@ -116,7 +116,7 @@ Use the context in the page component or as variables in `page-query`.
 </template>
 
 <page-query>
-query MyPage($customValue: String) {
+query ($customValue: String) {
   ...
 }
 </page-query>

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -7,7 +7,7 @@ Use the `@paginate` directive in your GraphQL query to add automatic pagination 
 Place the `@paginate` directive after the collection you want to paginate.
 
 ```graphql
-query Blog($page: Int) {
+query ($page: Int) {
   allBlogPost(perPage: 10, page: $page) @paginate {
     pageInfo {
       totalPages
@@ -29,7 +29,7 @@ query Blog($page: Int) {
 Place the `@paginate` directive after the `belongsTo` field you want to paginate.
 
 ```graphql
-query Category($page: Int) {
+query ($page: Int) {
   category {
     title
     belongsTo(perPage: 10, page: $page) @paginate {
@@ -80,7 +80,7 @@ export default {
 </script>
 
 <page-query>
-query Blog($page: Int) {
+query ($page: Int) {
   allBlogPost(perPage: 10, page: $page) @paginate {
     pageInfo {
       totalPages

--- a/docs/querying-data.md
+++ b/docs/querying-data.md
@@ -19,7 +19,7 @@ Working with GraphQL in Gridsome is easy and you don't need to know much about G
 </template>
 
 <page-query>
-query Posts {
+query {
   posts: allWordPressPost {
     edges {
       node {
@@ -54,7 +54,7 @@ You will notice that some of the root fields in your schema are prefixed with `a
 #### Find nodes sorted by title
 
 ```graphql
-query Posts {
+query {
   allPost(sortBy: "title", order: DESC) {
     edges {
       node {
@@ -68,7 +68,7 @@ query Posts {
 #### Sort a collection by multiple fields
 
 ```graphql
-query Posts {
+query {
   allPost(sort: [{ by: "featured" }, { by: "date" }]) {
     edges {
       node {
@@ -92,7 +92,7 @@ The other fields that do not start with `all` are your single entries. They are 
 #### Example query
 
 ```graphql
-query Post {
+query {
   post(id: "1") {
     title
   }
@@ -118,7 +118,7 @@ to fetch data from data sources. The results will be stored in a
 </template>
 
 <page-query>
-query Blog {
+query {
   posts: allWordPressPost {
     edges {
       node {
@@ -141,7 +141,7 @@ Every **Vue component** can have a `<static-query>` block with a GraphQL query t
 </template>
 
 <static-query>
-query Post {
+query {
   post(id: "1") {
     content
   }

--- a/docs/taxonomies.md
+++ b/docs/taxonomies.md
@@ -46,7 +46,7 @@ Now, we create a `Tag.vue` file in `src/templates` to have a template for our ta
 </template>
 
 <page-query>
-query Tag($id: ID!) {
+query ($id: ID!) {
   tag(id: $id) {
     title
     belongsTo {
@@ -72,7 +72,7 @@ That's it! The tag page above will show a list of posts with links to them.
 Place the `@paginate` directive after the `belongsTo` field to activate pagination. The query will have a `$page` variable available to pass into the `belongsTo` `page` argument.
 
 ```graphql
-query Tag($id: ID!, $page: Int) {
+query ($id: ID!, $page: Int) {
   tag(id: $id) {
     title
     belongsTo(page: $page) @paginate {

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -56,7 +56,7 @@ module.exports = {
 Template paths are available in the GraphQL schema with a `path` field. Use a `to` argument for getting paths to additional templates for a collection.
 
 ```graphql
-query Product ($id: ID!) {
+query ($id: ID!) {
   product(id: $id) {
     path               # path to the default template
     path(to:"reviews") # path to the reviews template
@@ -93,7 +93,7 @@ Pages generated from the `templates` configuration will have the node `id` avail
 </template>
 
 <page-query>
-query Post($id: ID!) {
+query ($id: ID!) {
   post(id: $id) {
     title
     content

--- a/examples/graphql-for-data.md
+++ b/examples/graphql-for-data.md
@@ -17,7 +17,7 @@ order: 1
 
 <!-- Query from local GraphQL data layer. -->
 <page-query>
-query Posts {
+query {
   allPost {
     edges {
       node {

--- a/examples/pagination-support.md
+++ b/examples/pagination-support.md
@@ -18,7 +18,7 @@ order: 5
 </template>
 
 <page-query>
-query Posts ($page: Int) {
+query ($page: Int) {
   allPost (perPage: 10, page: $page) @paginate {
     pageInfo {
       totalPages

--- a/examples/taxonomy-pages.md
+++ b/examples/taxonomy-pages.md
@@ -22,7 +22,7 @@ order: 5
 </template>
 
 <page-query>
-query Tag ($id: ID!) {
+query ($id: ID!) {
   tag (id: $id) {
     title
     belongsTo {

--- a/src/components/Examples.vue
+++ b/src/components/Examples.vue
@@ -46,7 +46,7 @@ export default {
 </script>
 
 <static-query>
-query Example {
+query {
   examples:	allExample (sortBy: "order", order: ASC)  {
   	edges {
   		node {

--- a/src/components/home/HomeBlog.vue
+++ b/src/components/home/HomeBlog.vue
@@ -30,7 +30,7 @@ export default {
 </script>
 
 <static-query>
-query BlogPosts {
+query {
   posts: allBlogPost {
     edges {
       node {

--- a/src/components/home/HomeHowItWorks.vue
+++ b/src/components/home/HomeHowItWorks.vue
@@ -102,7 +102,7 @@
 
 
 <static-query>
-query Example {
+query {
   example (path: "/examples/templates") {
     content
   }

--- a/src/components/home/HomeIntro.vue
+++ b/src/components/home/HomeIntro.vue
@@ -38,7 +38,7 @@
 </template>
 
 <static-query>
-query HomeIntro {
+query {
   metaData {
     gridsomeVersion
   }

--- a/src/components/home/HomeIntroSimple.vue
+++ b/src/components/home/HomeIntroSimple.vue
@@ -49,7 +49,7 @@
 </template>
 
 <static-query>
-query HomeIntro {
+query {
   metadata {
     gridsomeVersion
   }

--- a/src/components/home/HomeTabs.vue
+++ b/src/components/home/HomeTabs.vue
@@ -79,7 +79,7 @@ export default {
 
 
 <static-query>
-query Example {
+query {
   example (path: "/examples/templates") {
     content
   }

--- a/src/layouts/partials/Header.vue
+++ b/src/layouts/partials/Header.vue
@@ -73,7 +73,7 @@
 </template>
 
 <static-query>
-query Header {
+query {
   metadata {
     gridsomeVersion
   }

--- a/src/pages/Blog.vue
+++ b/src/pages/Blog.vue
@@ -17,7 +17,7 @@
 </template>
 
 <page-query>
-query BlogPosts {
+query {
   posts: allBlogPost {
     edges {
       node {

--- a/src/pages/Starters.vue
+++ b/src/pages/Starters.vue
@@ -29,7 +29,7 @@ export default {
 </script>
 
 <page-query>
-query Starters {
+query {
   defaultStarters: allStarter (
     sort: [{ by: "index", order: ASC }]
     filter: {

--- a/src/templates/BlogPost.vue
+++ b/src/templates/BlogPost.vue
@@ -23,7 +23,7 @@
 </template>
 
 <page-query>
-query BlogPost ($id: ID!) {
+query ($id: ID!) {
   post: blogPost (id: $id) {
     title
     date (format: "D. MMMM YYYY")

--- a/src/templates/Contributor.vue
+++ b/src/templates/Contributor.vue
@@ -27,7 +27,7 @@
 </template>
 
 <page-query>
-query Contributor ($id: ID!) {
+query ($id: ID!) {
   contributor (id: $id) {
     id
     title

--- a/src/templates/DocPage.vue
+++ b/src/templates/DocPage.vue
@@ -5,7 +5,7 @@
 </template>
 
 <page-query>
-query DocPage ($id: ID!) {
+query ($id: ID!) {
   doc: docPage (id: $id) {
     title
     headings (depth: h1) {

--- a/src/templates/LearnPage.vue
+++ b/src/templates/LearnPage.vue
@@ -5,7 +5,7 @@
 </template>
 
 <page-query>
-query LearnPage ($id: ID!) {
+query ($id: ID!) {
   doc: learnPage (id: $id) {
     path
     content

--- a/src/templates/Platform.vue
+++ b/src/templates/Platform.vue
@@ -23,7 +23,7 @@
 </template>
 
 <page-query>
-query Platform($id: ID!) {
+query ($id: ID!) {
   platform(id: $id) {
     title
     belongsTo(sortBy: "index") {

--- a/src/templates/Starter.vue
+++ b/src/templates/Starter.vue
@@ -165,7 +165,7 @@ export default {
 </script>
 
 <page-query>
-query Starters($id: ID!) {
+query ($id: ID!) {
   starter(id: $id) {
     title
     repo


### PR DESCRIPTION
The query operation name is not very useful for Gridsome sites, and makes it just harder for new comers to GraphQL to understand it. The optional operation name can often be confused with the GraphQL Collection name. 