### PR TITLE
fix: layout on plugin page in certain breakpoint

### DIFF
--- a/src/assets/style/plugins.scss
+++ b/src/assets/style/plugins.scss
@@ -126,6 +126,8 @@
 }
 
 .plugin-post {
+  overflow: auto;
+  
   &__meta {
     padding-bottom: 15px;
     border-bottom: 1px solid var(--border-color);


### PR DESCRIPTION
Fixes #298.

Normally I feel confident with CSS, but why this works, without a deeper inspection, is a miracle to me, hence may be considered a hotfix.

Is somewhat related to `<pre>` code blocks not scrolling horizontally, didn't figure out a better fix yet though.