### PR TITLE
2column layout fix

### DIFF
--- a/src/assets/style/plugins.scss
+++ b/src/assets/style/plugins.scss
@@ -126,6 +126,8 @@
 }
 
 .plugin-post {
+  overflow: auto;
+  
   &__meta {
     padding-bottom: 15px;
     border-bottom: 1px solid var(--border-color);

--- a/src/assets/style/plugins.scss
+++ b/src/assets/style/plugins.scss
@@ -126,7 +126,6 @@
 }
 
 .plugin-post {
-  overflow: auto;
   
   &__meta {
     padding-bottom: 15px;

--- a/src/components/Section.vue
+++ b/src/components/Section.vue
@@ -38,6 +38,7 @@ export default {
   position: relative;
   width: 100%;
   flex: 1;
+  min-width: 0;
 
   &--secondary {
     background-color: var(--bg-secondary);

--- a/src/layouts/Docs.vue
+++ b/src/layouts/Docs.vue
@@ -1,6 +1,6 @@
 <template>
   <Layout class="has-sidebar docs-page" :footer="false">
-    <div class="container flex flex-align-top">
+    <div class="container flex flex-align-top container-main">
       <div class="sidebar">
         <template v-if="links" v-for="(group, i1) in links">
           <h3 class="menu-item" :key="`title-${i1}`">{{ group.title }}</h3>

--- a/src/layouts/Starters.vue
+++ b/src/layouts/Starters.vue
@@ -1,6 +1,6 @@
 <template>
   <Layout class="has-sidebar starter-page" :footer="false">
-    <div class="container flex flex-align-top">
+    <div class="container flex flex-align-top container-main">
 
       <div class="sidebar">
 

--- a/src/templates/Plugin.vue
+++ b/src/templates/Plugin.vue
@@ -1,6 +1,6 @@
 <template>
   <Layout :footer="false">
-    <div class="plugins container flex flex-align-top" style="position: relative;">
+    <div class="plugins container flex flex-align-top container-main" style="position: relative;">
       
       <AisInstantSearchSsr class="sidebar plugins__sidebar">
         <AisConfigure


### PR DESCRIPTION
Fixes #316, which is basically the same as #298, the old fix was not general enough, so I replaced it with new one. Explanation for weird behavior found here: https://stackoverflow.com/questions/28896807/pre-code-element-with-horizontal-scrollbar-breaks-the-flex-layout-on-firefox

Tested on latest Edge/Chrome/Firefox/Safari via Browserstack. 