### PR TITLE
Fix ZEIT Now branding

### DIFF
--- a/src/components/home/HomeHowItWorkSimple.vue
+++ b/src/components/home/HomeHowItWorkSimple.vue
@@ -44,7 +44,7 @@
       <Card title="Deploy">
         <h4>Static Web Hosts & CDNs</h4>
         <p>
-          <g-link to="/docs/deploy-to-netlify/">Netlify</g-link>, <g-link to="/docs/deploy-to-amplify/">AWS Amplify</g-link>, <g-link to="/docs/deploy-to-zeit-now/">Zeit Now</g-link>, <g-link to="/docs/deploy-to-amazon-s3/">Amazon S3</g-link>, Surge.sh, Aerobatic & many more.
+          <g-link to="/docs/deploy-to-netlify/">Netlify</g-link>, <g-link to="/docs/deploy-to-amplify/">AWS Amplify</g-link>, <g-link to="/docs/deploy-to-zeit-now/">ZEIT Now</g-link>, <g-link to="/docs/deploy-to-amazon-s3/">Amazon S3</g-link>, Surge.sh, Aerobatic & many more.
         </p>
 
         <ul class="bullet-list mb">

--- a/src/components/home/HomeHowItWorks.vue
+++ b/src/components/home/HomeHowItWorks.vue
@@ -87,7 +87,7 @@
 
       <Card class="text-center container-mini mb">
         <h4>Static Web Hosts</h4>
-        <p> <g-link to="/docs/deploy-to-netlify/">Netlify</g-link>, <g-link to="/docs/deploy-to-amplify/">AWS Amplify</g-link>, <g-link to="/docs/deploy-to-zeit-now/">Zeit Now</g-link>, <g-link to="/docs/deploy-to-amazon-s3/">Amazon S3</g-link>, Surge.sh, Aerobatic, Now.sh & many more.</p>
+        <p> <g-link to="/docs/deploy-to-netlify/">Netlify</g-link>, <g-link to="/docs/deploy-to-amplify/">AWS Amplify</g-link>, <g-link to="/docs/deploy-to-zeit-now/">ZEIT Now</g-link>, <g-link to="/docs/deploy-to-amazon-s3/">Amazon S3</g-link>, Surge.sh, Aerobatic, Now.sh & many more.</p>
       </Card>
 
       <p class="home-links text-center">


### PR DESCRIPTION
This PR fixes the branding for ZEIT Now on a couple pages.

Follow up to #248 