### PR TITLE
small optimizations in some homepage animations, header backdrop bluriness

### DIFF
--- a/src/assets/style/animations.scss
+++ b/src/assets/style/animations.scss
@@ -78,6 +78,8 @@
   position: absolute;
   left: 0;
   right: 0;
+  top: 0;
+  width: 100%;
 }
 .rotate-enter-to {
   transform: translateY(0);

--- a/src/components/Connect.vue
+++ b/src/components/Connect.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="connect">
     
-    <transition name="fade">
-      <div class="connect__slide" key=1 v-if="activeSlide == 0"><g-image class="connect__logos" src="~/assets/images/connect-logos.png" width="1180" blur="10" retina="true" alt="The Modern Web Logos" /></div>
-      <div  class="connect__slide"key=2 v-else-if="activeSlide == 1"><g-image class="connect__logos" src="~/assets/images/connect-logos-2.png" width="1180" blur="10" retina="true" alt="The Modern Web Logos 2" /></div>
-      <div class="connect__slide" key=3 v-else-if="activeSlide == 2"><g-image class="connect__logos" src="~/assets/images/connect-logos-3.png" width="1180" blur="10" retina="true" alt="The Modern Web Logos 3" /></div>
-    </transition>
+    <transition-group name="fade">
+      <div class="connect__slide" key=1 v-show="activeSlide == 0"><g-image class="connect__logos" src="~/assets/images/connect-logos.png" width="1180" blur="10" retina="true" alt="The Modern Web Logos" /></div>
+      <div class="connect__slide" key=2 v-show="activeSlide == 1"><g-image class="connect__logos" src="~/assets/images/connect-logos-2.png" width="1180" blur="10" retina="true" alt="The Modern Web Logos 2" /></div>
+      <div class="connect__slide" key=3 v-show="activeSlide == 2"><g-image class="connect__logos" src="~/assets/images/connect-logos-3.png" width="1180" blur="10" retina="true" alt="The Modern Web Logos 3" /></div>
+    </transition-group>
     
     <g-image class="connect__main" src="~/assets/images/connect-bg.png" width="1180" blur="10" retina="true" alt="The Modern Web Background" />
 
@@ -32,9 +32,14 @@ export default {
   },
 
   mounted () {
-    this._counter = setInterval(() => {
-      this.activeSlide = (this.activeSlide + 1) % 3
-    }, 1500)
+    (($vm) => {
+      (function animate () {
+        $vm._counter = setTimeout(() => {
+          $vm.activeSlide = ($vm.activeSlide + 1) % 3
+          requestAnimationFrame(animate)
+        }, 1500)
+      })()
+    })(this)
   },
 
   destroyed () {

--- a/src/components/home/HomeHowItWorkSimple.vue
+++ b/src/components/home/HomeHowItWorkSimple.vue
@@ -127,9 +127,9 @@ export default {
     border-radius: 100%;
     z-index: 0;
     margin-bottom: 1rem;
-    animation: bounce 2s infinite;
 
     svg {
+      animation: bounce 2s infinite;
       width: 70px;
       height: 70px;
     }

--- a/src/components/home/HomeHowItWorkSimple.vue
+++ b/src/components/home/HomeHowItWorkSimple.vue
@@ -127,9 +127,9 @@ export default {
     border-radius: 100%;
     z-index: 0;
     margin-bottom: 1rem;
+    animation: bounce 2s infinite;
 
     svg {
-      animation: bounce 2s infinite;
       width: 70px;
       height: 70px;
     }

--- a/src/components/home/HomeIntroSimple.vue
+++ b/src/components/home/HomeIntroSimple.vue
@@ -6,26 +6,26 @@
 
         <h1 class="intro__title">
           <span>A Vue.js framework for</span>
-          <transition name="rotate">
-            <div v-if="currentText == 0" key="0">
+          <transition-group name="rotate" class="intro__keywords">
+            <div v-show="currentText == 0" key="0">
               Static Websites
             </div>
-            <div v-else-if="currentText == 1" key="1">
+            <div v-show="currentText == 1" key="1">
               The JAMstack
             </div>
-            <div v-else-if="currentText == 2" key="2">
+            <div v-show="currentText == 2" key="2">
               Headless CMSs
             </div>
-            <div v-else-if="currentText == 3" key="3">
+            <div v-show="currentText == 3" key="3">
               Markdown files
             </div>
-            <div v-else-if="currentText == 4" key="4">
+            <div v-show="currentText == 4" key="4">
               Modern PWAs
             </div>
-            <div v-else-if="currentText == 5" key="5">
+            <div v-show="currentText == 5" key="5">
               Serverless Apps
             </div>
-          </transition>
+          </transition-group>
         </h1>
 
         <p class="intro__lead lead post mb">
@@ -112,6 +112,11 @@ export default {
 
   &__info {
     font-size: .9rem;
+  }
+
+  &__keywords {
+    position: relative;
+    display: block;
   }
 }
 </style>

--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -1,13 +1,8 @@
 <template>
-    <div id="app" dark>
-      <Header />
-      <main id="main" :class="mainClass">
-        <slot />
-      </main>
-      <LazyHydrate ssr-only v-if="footer !== false">
-        <Footer />
-      </LazyHydrate>
-    </div>
+  <div id="app" dark>
+    <Header />
+    <slot />
+  </div>
 </template>
 
 <script>

--- a/src/layouts/partials/Header.vue
+++ b/src/layouts/partials/Header.vue
@@ -115,7 +115,6 @@ header {
   flex-wrap: nowrap;
   position: sticky;
   transition: background-color .3s, border-color, .3s;
-  backdrop-filter: blur(4px);
 
 
   .header-bar {
@@ -133,6 +132,14 @@ header {
   .header-inner {
     padding: 0 var(--space);
     min-height: var(--header-height);
+  }
+
+  @media screen and (min-width: 992px) and (max-resolution: 1) {
+    backdrop-filter: blur(4px);
+  }
+
+  @media screen and (min-width: 992px) and (-webkit-max-device-pixel-ratio: 1) {
+    backdrop-filter: blur(4px);
   }
 }
 </style>


### PR DESCRIPTION
When browsing on 4k screen with 200% scaling I noticed, that scrolling is quite janky. After trying to optimize some animations (where I expect attribute changes to be cheaper then DOM tree updates), I found the main culprit: *backdrop-filter: blur(4px)* on the header. While the site was smooth when tested on an external 1080p monitor, the above CSS attribute didn't scale that well with 4K resolution. I made it so that on higher pixel-density screens with higher resolution *backdrop-filter: blur(4px)* doesn't take effect so that scrolling is much more smooth.

I still noticed small lags when scrolling near the "A better way to build websites & apps" section on the homepage but that's a battle for another day.