### PR TITLE
docs: added vuetify with treeshaking example

### DIFF
--- a/docs/assets-css.md
+++ b/docs/assets-css.md
@@ -458,21 +458,15 @@ yarn add deepmerge fibers sass-loader@7.3.1 vuetify-loader --dev
   also remove `node-sass` package if it's installed, otherwise build will fail.
 2. Configure webpack in `gridsome.server.js`
 ```js
-const nodeExternals = require('webpack-node-externals');
 const VuetifyLoaderPlugin = require('vuetify-loader/lib/plugin');
 
 module.exports = (api) => {
   api.chainWebpack((config, { isServer }) => {
     config.plugin('vuetify-loader').use(VuetifyLoaderPlugin);
-    if (isServer) {
-      config.externals([
-        nodeExternals({
-          whitelist: [/^vuetify/],
-        }),
-      ]);
-    }
   });
 ```
+>❗️Note: `webpack-node-externals` is not needed in this case.
+
 3. Install plugin in `main.js`
 ```js
 import Vuetify from 'vuetify/lib/framework';

--- a/docs/assets-css.md
+++ b/docs/assets-css.md
@@ -368,8 +368,13 @@ import DefaultLayout from '~/layouts/Default.vue'
 export default function (Vue, { head }) {
   head.link.push({
     rel: 'stylesheet',
-    href: 'https://fonts.googleapis.com/icon?family=Material+Icons'
+    href: 'https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css',
   })
+  
+  head.link.push({
+    rel: 'stylesheet',
+    href: 'https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900',
+  });
 
   Vue.use(Vuetify)
   
@@ -387,8 +392,13 @@ import DefaultLayout from '~/layouts/Default.vue'
 export default function (Vue, { appOptions, head }) {
   head.link.push({
     rel: 'stylesheet',
-    href: 'https://fonts.googleapis.com/icon?family=Material+Icons'
+    href: 'https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css',
   })
+  
+  head.link.push({
+    rel: 'stylesheet',
+    href: 'https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900',
+  });
   
   const opts = { ... } //opts includes, vuetify themes, icons, etc.
   Vue.use(Vuetify)
@@ -431,6 +441,57 @@ module.exports = function (api) {
   api.loadSource(store => {
     // Use the Data store API here: https://gridsome.org/docs/data-store-api
   })
+}
+```
+
+Or save your bundle size by using [vuetify treeshaking](https://vuetifyjs.com/en/customization/a-la-carte).
+
+1. Install dependencies
+```shell
+# With npm
+npm install deepmerge fibers sass-loader@7.3.1 vuetify-loader --save-dev
+
+# With yarn
+yarn add deepmerge fibers sass-loader@7.3.1 vuetify-loader --dev
+```
+>❗️Note: sass-loader must be lower than 8 version,
+  also remove `node-sass` package if it's installed, otherwise build will fail.
+2. Configure webpack in `gridsome.server.js`
+```js
+const nodeExternals = require('webpack-node-externals');
+const VuetifyLoaderPlugin = require('vuetify-loader/lib/plugin');
+
+module.exports = (api) => {
+  api.chainWebpack((config, { isServer }) => {
+    config.plugin('vuetify-loader').use(VuetifyLoaderPlugin);
+    if (isServer) {
+      config.externals([
+        nodeExternals({
+          whitelist: [/^vuetify/],
+        }),
+      ]);
+    }
+  });
+```
+3. Install plugin in `main.js`
+```js
+import Vuetify from 'vuetify/lib/framework';
+import 'vuetify/dist/vuetify.min.css';
+
+export default function (Vue, { appOptions, head }) {
+  head.link.push({
+    rel: 'stylesheet',
+    href: 'https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css',
+  });
+
+  head.link.push({
+    rel: 'stylesheet',
+    href: 'https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900',
+  });
+
+  const opts = {}; // opts includes, vuetify themes, icons, etc.
+  Vue.use(Vuetify);
+  appOptions.vuetify = new Vuetify(opts);
 }
 ```
 


### PR DESCRIPTION
👋
Spend evening trying to implement [tree shaking](https://vuetifyjs.com/en/customization/a-la-carte#a-la-carte-treeshaking), finally succeeded.
`app.js` decreased from 1mb to 300kb.
Works fine in my repo: https://github.com/souljorje/jamstack-workshop-frontend
Also replaced default font installation with proper way: https://vuetifyjs.com/en/customization/icons#installing-iconfonts

List of related issues:
https://github.com/gridsome/gridsome/issues/43
https://github.com/vuejs/vue-cli/issues/4513 - that's why I downgraded sass-loader to @7.3.0
https://github.com/vuetifyjs/vuetify/issues/7323 - that's why I removed `node-sass`