### PR TITLE
added Netlify recommendation to Starters

### DIFF
--- a/docs/how-to-contribute.md
+++ b/docs/how-to-contribute.md
@@ -45,7 +45,7 @@ To add a new blog post to the gridsome.org blog:
 - Run `gridsome develop` to preview the blog at `http://localhost:8000/blog`.
 - The content for the blog lives in the `/blog` folder.
 
-**Create contributor profile:**
+**Create your contributor profile:**
 - Add your avatar image to `/contributors/images`.
 - Add your name and info to `/contributors/contributors.yaml`.
 
@@ -61,25 +61,34 @@ To add a new blog post to the gridsome.org blog:
 
 ## Submit a Starter
 
-Contributing a new starter project is a great way to help other Gridsome users get off the ground quickly. While Starters are owned/maintained under your personal Github account, if you want one listed as an "official" Starter, you must commit the appropriate entry inside the Gridsome.org repo.
+Contributing a new starter project is a great way to help other Gridsome users to get off the ground quickly. If you want to list your project as an "official" Starter, you must commit the appropriate entry inside the Gridsome.org repo. 
+
+To add your Starter to gridsome.org:
+
+**Prepare repository:**
 
 - Clone [the Gridsome.org repo](https://github.com/gridsome/gridsome.org).
 - Run `yarn` to install all of the website's dependencies.
 
-**Create contributor profile:**
+**Create your contributor profile:**
 - Add your avatar image to `/contributors/images`.
 - Add your name and info to `/contributors/contributors.yaml`.
 
-**Add starter:**
+**Add your starter project:**
 - Add starter screenshot to `/starters/screenshots` (840x840px / 1680x1680 for retina).
 - Add starter details to end of this file `/starters/starters.yaml`.
 
-Gridsome Starters use the Github project README file for content.
+**Recommendations to your Starter project**
+
+- Naming convention: `gridsome-starter-<YOUR PROJECT SUFFIX>`
+- Add Netlify [build settings](https://gridsome.org/docs/deploy-to-netlify/) to support "Install now" with Netlify directly out of our Starters section 
+- Your project README is automatically used as Starter description
+
+**Committing your Starter**
 
 - Run `gridsome develop` to preview starter at `http://localhost:8000/starters`.
 - Commit and push to your fork
 - Create a pull request from your branch
-  - We recommend using a prefix of `starter`, like `starter/your-starter-id`.
 
 
 ## Submit to Showcase *


### PR DESCRIPTION
My own Starter didn't provide any netlify.toml, so that the option "Install Now" with "Deploy with Netlify" didn't deploy successful on Netlify. I wasn't aware of this prerequisite. Now, I added this to the documentation section.

I looked up various Starters and still not every Starter includes a netlify.toml. 
@hjvedvik: For https://github.com/gridsome/gridsome-starter-default I will open a PR as well. On top of this I will think of the idea to add notifications/PR to others as well ...