### PR TITLE
Some of documentation pages overflowing on the rigth on mobile

### DIFF
--- a/src/components/Section.vue
+++ b/src/components/Section.vue
@@ -37,7 +37,7 @@ export default {
   padding: calc(2% + var(--space)) 0;
   position: relative;
   width: 100%;
-  flex: 1;
+  flex: 1 auto;
 
   &--secondary {
     background-color: var(--bg-secondary);
@@ -77,7 +77,7 @@ export default {
     p {
       color: currentColor;
     }
-    
+
     h1, h2, h3, h4, a {
       color: #FFF;
     }


### PR DESCRIPTION
Browsing the documentation via mobile I had to rotate my Pixel to landscape to view the documentation. It affects most of the pages in the Basic Doc's. I am new to Gridsome and just deployed my [Blog site](https://eclecticsaddlebag.com), and needed to read some documentation. 

This changed the section class in the Section component to auto. This seems to fix the issue.