### PR TITLE
Edit/section overflow

### DIFF
--- a/src/assets/style/layouts.scss
+++ b/src/assets/style/layouts.scss
@@ -15,7 +15,7 @@
     width: 100%;
   }
   &-md { max-width: 760px }
-  &-base { max-width: 680px }
+  &-base { max-width: 90vw }
   &-sm { max-width: 630px }
   &-mini { max-width: 460px }
 

--- a/src/components/Section.vue
+++ b/src/components/Section.vue
@@ -37,7 +37,7 @@ export default {
   padding: calc(2% + var(--space)) 0;
   position: relative;
   width: 100%;
-  flex: 1;
+  flex: 1 auto;
 
   &--secondary {
     background-color: var(--bg-secondary);
@@ -77,7 +77,7 @@ export default {
     p {
       color: currentColor;
     }
-    
+
     h1, h2, h3, h4, a {
       color: #FFF;
     }

--- a/src/components/Section.vue
+++ b/src/components/Section.vue
@@ -37,7 +37,7 @@ export default {
   padding: calc(2% + var(--space)) 0;
   position: relative;
   width: 100%;
-  flex: 1 auto;
+  flex: 1 0;
 
   &--secondary {
     background-color: var(--bg-secondary);


### PR DESCRIPTION
Refer: #402
The mobile issue was causes by a CSS container class.
In the Section component, the computed value `SectionClassInner` concats a `container-base` class. 

This class was set as `&-base { max-width: 680px }` and I changed to use `90vw` and this seems to work in this isolated case of the smaller portrait mobile devices. 
