### PR TITLE
[FIX] switch zeit now to Vercel Now for gridsome deployment

### DIFF
--- a/docs/deploy-to-vercel-now.md
+++ b/docs/deploy-to-vercel-now.md
@@ -1,6 +1,6 @@
-# Deploy to ZEIT Now
+# Deploy to Vercel Now
 
-[ZEIT Now](https://zeit.co) is a cloud platform for websites and serverless APIs, that you can use to deploy your Gridsome projects to your personal domain (or a free `.now.sh` suffixed URL).
+[Vercel Now](https://vercel.com) is a cloud platform for websites and serverless APIs, that you can use to deploy your Gridsome projects to your personal domain (or a free `.now.sh` suffixed URL).
 
 This guide will show you how to get started in a few quick steps:
 
@@ -20,7 +20,7 @@ You can deploy your application by running the following command in the root of 
 now
 ```
 
-**Alternatively**, you can also use their integration for [GitHub](https://zeit.co/github) or [GitLab](https://zeit.co/gitlab).
+**Alternatively**, you can also use their integration for [GitHub](https://vercel.com/github) or [GitLab](https://vercel.com/gitlab).
 
 That’s all!
 


### PR DESCRIPTION
- Zeit just rebranded to Vercel and this PR changes the deployment guidelines to deployment for gridsome