### PR TITLE
Path mapping works out of box

### DIFF
--- a/docs/dev-tools.md
+++ b/docs/dev-tools.md
@@ -40,24 +40,7 @@ gridsome-helper-json support `<g-image>`, `<g-link>` and `<Pager>`.
 
 ![autocompletion-attribute](./images/autocompletion-attribute.png)
 
-### Path mapping
 
-Gridsome can use Webpack's alias.  
-Vetur provide [path mapping](https://github.com/vuejs/vetur/blob/master/docs/setup.md#path-mapping).
-
-1. At project root create a `jsconfig.json`.
-
-```json
-{
-  "include": ["./src/**/*"],
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
-  }
-}
-```
 
 2. Add suffix `.vue` where import syntax.
 


### PR DESCRIPTION
I wanted to use `@` alias for imports and noticed it worked out of the box . So, we don't have to configure it further as stated in the docs. ?Perhaps remove this from the docs for less confusion.