### PR TITLE
changed ZEIT Now to Vercel

### DIFF
--- a/docs/deploy-to-zeit-now.md
+++ b/docs/deploy-to-zeit-now.md
@@ -1,6 +1,6 @@
-# Deploy to ZEIT Now
+# Deploy to Vercel 
 
-[ZEIT Now](https://zeit.co) is a cloud platform for websites and serverless APIs, that you can use to deploy your Gridsome projects to your personal domain (or a free `.now.sh` suffixed URL).
+[Vercel](https://vercel.com) (formerly ZEIT) is a cloud platform for websites and serverless APIs, that you can use to deploy your Gridsome projects to your personal domain (or a free `.now.sh` suffixed URL).
 
 This guide will show you how to get started in a few quick steps:
 
@@ -20,7 +20,7 @@ You can deploy your application by running the following command in the root of 
 now
 ```
 
-**Alternatively**, you can also use their integration for [GitHub](https://zeit.co/github) or [GitLab](https://zeit.co/gitlab).
+**Alternatively**, you can also use their integration for [GitHub](https://vercel.com/github) or [GitLab](https://vercel.com/gitlab).
 
 That’s all!
 


### PR DESCRIPTION
Because of the rebranding of ZEIT, all names changed to Vercel.