### PR TITLE
Add gzip compression to Gitlab Pages example

### DIFF
--- a/docs/deploy-to-gitlab.md
+++ b/docs/deploy-to-gitlab.md
@@ -24,7 +24,7 @@ pages:
   script:
     - npm install
     - npm run build
-    # Optional: this gzips all files, so Gitlab can serve compressed assets.
+    # Optional: this gzips all files, so GitLab can serve compressed assets.
     - gzip -k -6 $(find public -type f)
   artifacts:
     paths:

--- a/docs/deploy-to-gitlab.md
+++ b/docs/deploy-to-gitlab.md
@@ -24,7 +24,7 @@ pages:
   script:
     - npm install
     - npm run build
-    # this gzips all files, so Gitlab can serve compressed assets. optional
+    # Optional: this gzips all files, so Gitlab can serve compressed assets.
     - gzip -k -6 $(find public -type f)
   artifacts:
     paths:

--- a/docs/deploy-to-gitlab.md
+++ b/docs/deploy-to-gitlab.md
@@ -24,6 +24,7 @@ pages:
   script:
     - npm install
     - npm run build
+    - gzip -k -6 $(find public -type f)
   artifacts:
     paths:
       - public

--- a/docs/deploy-to-gitlab.md
+++ b/docs/deploy-to-gitlab.md
@@ -24,6 +24,7 @@ pages:
   script:
     - npm install
     - npm run build
+    # this gzips all files, so Gitlab can serve compressed assets. optional
     - gzip -k -6 $(find public -type f)
   artifacts:
     paths:


### PR DESCRIPTION
Gitlab Pages requires manual work in order to send gzipped content. See https://webd97.de/post/gitlab-pages-compression/