### PR TITLE
Update addSchemaResolvers to include addSchemaTypes

### DIFF
--- a/docs/schema-api.md
+++ b/docs/schema-api.md
@@ -71,19 +71,14 @@ addSchemaResolvers({
 This example adds a new `fullName` field on the `User` type which merges two fields:
 
 ```js
-api.loadSource(({ addSchemaTypes }) => {
-  addSchemaTypes(`
-      type User implements Node @infer {
-        fullName: String
-      }
-  `);
-});
-
 api.loadSource(({ addSchemaResolvers }) => {
   addSchemaResolvers({
     User: {
-      fullName(obj) {
-        return `${obj.firstName} ${obj.lastName}`
+      fullName: {
+        type: 'String',
+        resolve(obj) {
+          return `${obj.firstName} ${obj.lastName}`
+        }
       }
     }
   })
@@ -95,18 +90,11 @@ api.loadSource(({ addSchemaResolvers }) => {
 This example adds a `title` field on the `Post` type with an argument to uppercase the returned value:
 
 ```js
-api.loadSource(({ addSchemaTypes }) => {
-  addSchemaTypes(`
-      type Post implements Node @infer {
-        title: String
-      }
-  `);
-});
-
 api.loadSource(({ addSchemaResolvers }) => {
   addSchemaResolvers({
     Post: {
       title: {
+        type: 'String',
         args: {
           uppercased: 'Boolean'
         },

--- a/docs/schema-api.md
+++ b/docs/schema-api.md
@@ -71,6 +71,14 @@ addSchemaResolvers({
 This example adds a new `fullName` field on the `User` type which merges two fields:
 
 ```js
+api.loadSource(({ addSchemaTypes }) => {
+  addSchemaTypes(`
+      type User implements Node @infer {
+        fullName: String
+      }
+  `);
+});
+
 api.loadSource(({ addSchemaResolvers }) => {
   addSchemaResolvers({
     User: {
@@ -87,6 +95,14 @@ api.loadSource(({ addSchemaResolvers }) => {
 This example adds a `title` field on the `Post` type with an argument to uppercase the returned value:
 
 ```js
+api.loadSource(({ addSchemaTypes }) => {
+  addSchemaTypes(`
+      type Post implements Node @infer {
+        title: String
+      }
+  `);
+});
+
 api.loadSource(({ addSchemaResolvers }) => {
   addSchemaResolvers({
     Post: {


### PR DESCRIPTION
My understanding is that the addSchemaResolvers API requires the caller to also call addSchemaTypes to add the field to the parent Node. The examples omit the addSchemaTypes call, so this change updates the examples to include the required calls.