### PR TITLE
Remove reference to canonicalLink field

### DIFF
--- a/docs/how-to-contribute.md
+++ b/docs/how-to-contribute.md
@@ -51,7 +51,7 @@ To add a new blog post to the gridsome.org blog:
 
 **Setup blog post:**
 - Add a new folder following the pattern `/blog/yyyy-mm-dd-title` (for example, 2018-09-14-say-hello-to-gridsome). Within this newly created folder add an `index.md` file.
-- Add `title`, `date`, `author`, and `tags` to the frontmatter of your `index.md`. If you are cross posting your post you can add `canonicalLink` for SEO benefits.
+- Add `title`, `date`, `author`, and `tags` to the frontmatter of your `index.md`.
 - If your blog post contains images add them to your blog post folder and reference them in your post's `index.md`.
 - Ensure any links to **gridsome.org pages** are relative links - `/docs/how-to-contribute` instead of `https://gridsome.org/docs/how-to-contribute`
 - Commit and push to your fork


### PR DESCRIPTION
The blog submission instructions reference a canonicalLink field to add the rel=canonical tag to the <head>. It doesn't look like this was ever implemented. Since none of the existing blog posts use an external rel=canonical, removing this guidance for now. We can always implement it pretty simply if we need to (see 0cb886ed33b19c6d49a5ff7621cabcfbc6d6d857).

Fixes #440