### PR TITLE
Edit disqus component tag

### DIFF
--- a/docs/guide-comments.md
+++ b/docs/guide-comments.md
@@ -6,11 +6,11 @@ Adding comments to a static site can be easy, you have the option to use either 
 Disqus is an external service that injects an iframe on your site, one easy way to use Disqus with Gridsome is to use the package [vue-disqus](https://github.com/ktquez/vue-disqus) that provides you with a custom component that you can use across your project.
 
 #### Sign up on Disqus
-First step is to sign up for an account on [Disqus](https://disqus.com/). When presented with the option you want to choose 'I want to install Disqus on my site'. Continue by filling in all necessary information about your site and when you are asked 'What platform is your site on?', pick 'Universal Code' at the bottom of the page. 
+First step is to sign up for an account on [Disqus](https://disqus.com/). When presented with the option you want to choose 'I want to install Disqus on my site'. Continue by filling in all necessary information about your site and when you are asked 'What platform is your site on?', pick 'Universal Code' at the bottom of the page.
 
 Complete the setup of your site and take note of your `Shortname` because this will be used later.
 
-![shortname](https://i.imgur.com/Ui1aoYi.png) 
+![shortname](https://i.imgur.com/Ui1aoYi.png)
 
 #### Install vue-disqus
 You can use vue-disqus for easier implementation or use disqus directly, but this guide is using vue-disqus.
@@ -19,7 +19,7 @@ You can use vue-disqus for easier implementation or use disqus directly, but thi
 or with npm
 `npm install vue-disqus`
 
-After it has been added to your package.json and installed you need to import vue-disqus in your `main.js` which is located directly in the `src` directory, and added to the vue instance. 
+After it has been added to your package.json and installed you need to import vue-disqus in your `main.js` which is located directly in the `src` directory, and added to the vue instance.
 
 ```js
 import VueDisqus from 'vue-disqus'
@@ -32,7 +32,7 @@ export default function (Vue, { head })  {
 Now you are free to use the disqus component anywhere you want, simply use it like this:
 
 ```js
-<vue-disqus shortname="mygridsomesite" :identifier="$page.post.title"></vue-disqus>
+<Disqus shortname="mygridsomesite" :identifier="$page.post.title" />
 ```
 
 You need to provide a shortname which you can find on [Disqus](https://disqus.com/) under your site you configured after you signed up. You also need to provide an identifier, in this example we used the blogpost title from the GraphQL query.


### PR DESCRIPTION
While working to implement commenting to my [Blog](https://www.eclecticsaddlebag.com/), the Disqus section was not working. The example:

```
<vue-disqus shortname="mygridsomesite" :identifier="$page.post.title"></vue-disqus>
```
The solution which worked for me:
```
<Disqus shortname="mygridsomesite" :identifier="$page.post.title" />
```
You can view the source code of my [Blog](https://github.com/eclectic-coding/gridsome-graphql-markdown) if you need to.