### PR TITLE
@click or v-on:click?

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -9,7 +9,7 @@ Here’s an example of a file we’ll call `Card.vue` inside `src/components/`:
 <template>
   <div class="card">
     {{ message }}
-    <button @click="onClick">
+    <button v-on:click="onClick">
       Change
     </button>
   </div>


### PR DESCRIPTION
Is the documentation supposed to be geared towards using `@click` or `v-on:click`?  My thinking for changing to use v-on:click is that most people who are using gridsome or other vue js static site generators are not actually used to Vue JS. This would mean it would be easier to just always use `v-on:click` because you know that we will always use the `v-on` prefix.  Globally switching to only using the `v-on` version of event handlers also adds uniformity to reading the docs.  Just close the request if we are going to be using `@click` instead of `v-on:click`.