### PR TITLE
Apply consistent style for whitespace around headers

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -13,8 +13,6 @@ MD009: false
 MD012: false
 # line-length
 MD013: false
-# blanks-around-headings/blanks-around-headers
-MD022: false
 # no-duplicate-heading/no-duplicate-header
 MD024: false
 # single-title/single-h1

--- a/blog/2019-05-10-gridsome-06/index.md
+++ b/blog/2019-05-10-gridsome-06/index.md
@@ -93,6 +93,7 @@ Add data by using `$context` in Vue component.
 Read more about the [Pages API](/docs/pages-api/)
 
 ## New function for fetching internal pages
+
 A new function available in [Client API](/docs/client-api/) lets you fetch internal pages. This is perfect for building lightboxes or «Click for more» pagination etc.
 
 ```js
@@ -131,8 +132,8 @@ Gridsome has been importing `page-query` data with webpack dynamic imports which
 | `page-query.js` size | 510kb | *removed* |
 | Size of all JS chunks | 1000kb (excl. data chunks) | **570kb** (total) |
 
-
 ## New website design and starters library
+
 We redesigned https://gridsome.org to be more lightweight & clean. This is a website you will spend a lot of time at if you're developing Gridsome projects. We wanted it to require as little CPU power as possible. The old website killed CPUs with SVG path animations.
 
 We also added a [Starter library](/starters) to help anyone get quickly up and running with Gridsome.

--- a/blog/2019-09-17-gridsome-07/index.md
+++ b/blog/2019-09-17-gridsome-07/index.md
@@ -269,7 +269,7 @@ The `$id` variable in `<page-query>` for nodes has previously been a `String` ty
 🙌 You will probably get many deprecated messages on your current Gridsome project, but we think these changes are a right direction as we're getting close to a 1.0 version.
 
 ## How to upgrade
-Take a look here on [how to upgrade →](/docs/how-to-upgrade/).
 
+Take a look here on [how to upgrade →](/docs/how-to-upgrade/).
 
 [See full changelog →](https://github.com/gridsome/gridsome/blob/master/gridsome/CHANGELOG.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,15 +14,14 @@
 - **Automatic Code Splitting** - Builds ultra performance into every page.
 - **Plugin ecosystem** - Find a plugin for any job.
 
-
 ## What is the Jamstack?
 
 **Gridsome is a Jamstack framework**. Jamstack lets you build fast and secure sites and apps delivered by pre-rendering files and serving them directly from a CDN, removing the requirement to manage or run web servers.
 
 [Learn more about the Jamstack](/docs/jamstack).
 
-
 ## How it works
+
 Gridsome **generates static html** that hydrates into a <strong>Vue SPA</strong> once loaded in the browser. This means you can build both **static websites** & **dynamic apps** with Gridsome.
 
 Gridsome builds one `.html` file and one `.json` file for every page. After first page load it only uses the `.json` files to prefetch and load data for the next pages. It also builds a `.js` bundle for each page that needs it (code splitting).
@@ -33,8 +32,8 @@ Gridsome adds a `57kB min gzip` JS bundle size by default.(vue.js, vue-router, v
 
 [Learn more about how it works.](/docs/how-it-works)
 
-
 ## Prerequisites
+
 You should have basic knowledge about HTML, CSS, [Vue.js](https://vuejs.org) and how to use the [Terminal](https://www.linode.com/docs/tools-reference/tools/using-the-terminal/). Knowing how [GraphQL](https://www.graphql.com/) works is a plus, but not required. Gridsome is a great way to learn it.
 
 Gridsome requires [Node.js](https://nodejs.org/) (v8.3+) and recommends [Yarn](https://yarnpkg.com).
@@ -58,8 +57,8 @@ Gridsome requires [Node.js](https://nodejs.org/) (v8.3+) and recommends [Yarn](h
 1. Create `.vue` components in the `src/pages` directory to create page routes.
 2. Use `gridsome build` to generate static files in a `/dist` folder
 
-
 #### Learn more
+
 - [Core concepts](/docs/core-concepts/)
 - [How to host & deploy](/docs/deployment/)
 
@@ -76,4 +75,3 @@ import Newsletter from '@/components/Newsletter.vue'
 -    **[Nuxt.](https://nuxtjs.org/)** A Universal Vue.js Framework for server-side rendered (SSR) apps and websites. It also has a static site generator feature, but the main focus is SSR.
 
 -  **[Gatsby.js](https://www.gatsbyjs.org/)**  Gridsome is highly inspired by Gatsby.js (React.js based), which collects data sources and generates a static site from it. Gridsome is an alternative for Gatsby.js.
-

--- a/docs/assets-css.md
+++ b/docs/assets-css.md
@@ -1,7 +1,9 @@
 # Use CSS in Gridsome
+
 Global stylesheets and assets are usually located in the `src/assets` folder and imported into `src/main.js`.
 
 ## Import a global style
+
 Add this to `src/main.js` to import a global CSS file.
 
 ```js
@@ -9,8 +11,8 @@ import '~/assets/styles.css'
 ```
 💡 `~` is an alias to project **/src/** folder.
 
-
 ## Use SASS & CSS pre-processors
+
 To enable **SASS** you need to run command `npm install -D sass-loader node-sass` to install the required packages.
 
 Now you can import **.scss** files in **src/main.js**:
@@ -33,6 +35,7 @@ You can also use SASS in **Vue Components** with the `lang="scss"` attribute:
 [Learn more about using using Pre-Processors in Vue.js](https://vue-loader.vuejs.org/guide/pre-processors.html)
 
 ### Global Preprocessor Files (ie. variables, mixins)
+
 Often when you're working on a project, you'll have a set of variables, mixins, and framework variable overrides that you'll want to be automatically used in your components/layouts so you don't have to keep manually importing them.
 
 Start by installing `style-resources-loader`:
@@ -88,6 +91,7 @@ module.exports = {
 ```
 
 ## Add CSS to Vue Components
+
 In Vue Components you add styles inside a `<style>` tag.
 
 ```html
@@ -125,16 +129,15 @@ This will change the `.card` class in current component automatically to somethi
 
 Gridsome [Critical CSS plugin](/plugins/@gridsome/plugin-critical) extracts CSS from components in selected view port size and adds the CSS inline to `<head>`.
 
-
 ## Add a CSS framework
 
 ## Tailwind
+
 [TailwindCSS](https://tailwindcss.com) is a highly customizable, utility-based CSS framework that gives you all of the building blocks you need to build your project without any opinionated styles you have to fight to override. When using TailwindCSS, it is recommended to use [PostCSS-PurgeCSS](https://github.com/FullHuman/postcss-purgecss) which is a tool used to remove unused css; resulting in tiny file sizes.
 
-
 ### Add TailwindCSS with a Plugin
-The quickest and easiest way to get up and running with Tailwind CSS in your project is to install it with the [Gridsome Tailwind Plugin](/plugins/gridsome-plugin-tailwindcss). A Gridsome plugin will typically have the majority of the boilerplate and configuration done for you, eliminating a lot of the set up time.
 
+The quickest and easiest way to get up and running with Tailwind CSS in your project is to install it with the [Gridsome Tailwind Plugin](/plugins/gridsome-plugin-tailwindcss). A Gridsome plugin will typically have the majority of the boilerplate and configuration done for you, eliminating a lot of the set up time.
 
 ### Add TailwindCSS Manually
 
@@ -254,6 +257,7 @@ module.exports = {
 Be sure to restart the `gridsome develop` command to ensure the changes are compiled in the current build.
 
 ## Bulma
+
 ...plugin coming
 
 ## Buefy
@@ -304,6 +308,7 @@ export default function (Vue) {
 ```
 
 ## Bootstrap
+
 ...plugin coming
 
 ## BootstrapVue
@@ -485,4 +490,3 @@ export default function (Vue, { appOptions, head }) {
 ```
 
 Then you should be able to build now! You will find the files in your dist/folder.
-

--- a/docs/assets-fonts.md
+++ b/docs/assets-fonts.md
@@ -37,8 +37,8 @@ require('typeface-open-sans')
 
 And you're all done!
 
-
 ## Local Fonts
+
 It's important to note that the [aliases](/docs/directory-structure#aliases) mentioned in the Directory Structure don't work in your `<style>` tags because they aren't included into the Webpack bundle, so you need to use a relative path to them.
 
 Given the following directory:

--- a/docs/assets-scripts.md
+++ b/docs/assets-scripts.md
@@ -1,9 +1,11 @@
 # Add External Scripts
+
 It is really easy to use any external or third-party JavaScript with Gridsome. Since Gridsome is built on Vue, any method of importing external scripts in Vue works out-of-the-box with Gridsome.
 
 ## Add to Components
 
 ### Using an external Vue Plugin 
+
 If you want to use external Vue plugins inside your component without defining it globally, you can do so by importing the package inside your component and registering it for your component.
 
 Example:
@@ -31,6 +33,7 @@ export default {
 ```
 
 ### Using an external library 
+
 If you want to use a external JavaScript library inside your component, you can do so by importing the package and requiring it once the Vue components are mounted.
 
 Example:
@@ -59,11 +62,13 @@ export default {
 ```
 
 ## Add globally
+
 If you want scripts to be globally available you can add them to `src/main.js`.
 
 **Note:** Avoid injecting dependencies globally, and use it only if really necessary. Injecting locally into components is considered a better practice for code splitting.
 
-### Using an external Vue Plugin 
+### Using an external Vue Plugin
+
 To use any external Vue plugin with Gridsome, just import the required plugin and pass the it to Vue using `Vue.use` inside your main.js file:
 
 ```javascript
@@ -84,7 +89,8 @@ export default function (Vue) {
 
 In this example we are importing the `VueTypedJs` plugin inside our Gridsome project.
 
-### Using an external library 
+### Using an external library
+
 To use any external library on our Gridsome project, you may proxy it to a property of the Vue prototype object. Since all components inherit their methods from the Vue prototype object this will make your external library or libraries automatically available across any and all components with no global variables or anything to manually import.
 
 Example:
@@ -145,6 +151,7 @@ export default function (Vue) {
 ```
 
 ## Without SSR support
+
 `gridsome build` uses server-side rendering (SSR) to create a fully rendered page. If your Vue component does not support SSR or an external library (such as `jQuery`) changes the `DOM` element it won't be rendered properly. For these type of components, we suggest you to encapsulate the component inside `<ClientOnly></ClientOnly>` tags and import the library inside Vue's `mounted()` handler.
 
 For example, to use `vue-carousel` (that does not yet support SSR) you can do the following:

--- a/docs/assets-svg.md
+++ b/docs/assets-svg.md
@@ -1,7 +1,7 @@
 # Add SVG icons
 
-
 ## As plain markup
+
 The simplest way to use SVG icons in Gridsome is to just add them as normal markup. This gives a lot of flexibility with the power of Vue.  Here is an example where we have added an icon from https://feathericons.com/ as markup.
 
 ```html
@@ -23,6 +23,7 @@ The simplest way to use SVG icons in Gridsome is to just add them as normal mark
 ```
 
 ## Using SVGs as Components
+
 You can import SVGs as you do with any other Vue component with `vue-svg-loader`. Start by installing the library:
 
 ```shell

--- a/docs/body-html-attributes.md
+++ b/docs/body-html-attributes.md
@@ -1,7 +1,9 @@
 # Body & html attributes
+
 Gridsome can use [vue-meta](https://github.com/declandewet/vue-meta) to modify `<body>` and `<head>` attributes.
 
 ## Change attributes globally
+
 Global body or head attributes are added in `src/main.js`.
 
 ```js
@@ -14,8 +16,8 @@ export default function (Vue, { head }) {
 }
 ```
 
-
 ## Change attributes per page
+
 Custom attributes per page are added inside **.vue components**.
 For example, `src/pages/About.vue` would look something like this:
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -43,6 +43,7 @@ export default {
 [Learn more about Single File Components](https://vuejs.org/v2/guide/single-file-components.html)
 
 ## Import to other Pages or Components
+
 When you have created a component you can easily import it into your pages. In Gridsome projects it's recommended to put all your .vue components in the **src/components** folder and import them into **Pages** or **Layouts** like this:
 
 ```html

--- a/docs/config.md
+++ b/docs/config.md
@@ -18,6 +18,7 @@ module.exports = {
 Set a name for your project. The name is typically used in the title tag.
 
 ## siteDescription
+
 - Type `string`
 - Default `''`
 
@@ -77,6 +78,7 @@ module.exports = {
 Define routes and templates for collections.
 
 [Read more about using templates](/docs/templates/)
+
 ## metadata
 
 - Type `object`

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -1,11 +1,13 @@
 # Core concepts
 
 ## Pages
+
 [Pages](/docs/pages/) are created by adding **Vue Components** in `src/pages` folder. They use a file-based routing system. For example, `src/pages/About.vue` will be `mywebsite.com/about/`. Pages are used for simple pages and for pages that list collections (e.g., `/blog/`)
 
 [Learn more about Pages](/docs/pages/)
 
 ## Collections
+
 [Collections](/docs/collections/) are useful if you are going to have blog posts, tags, products etc. on your site. Collections can be sourced from any **Headless CMS, content APIs or Markdown files** by using [Source plugins](/plugins) or the [Data Store API](/docs/data-store-api/).
 
 ![Collections](./images/node-pages.png)
@@ -17,6 +19,7 @@ Collections are stored in a temporary [local GraphQL data layer](/docs/data-laye
 [Learn more about Collections](/docs/collections/)
 
 ## Templates
+
 [Templates](/docs/templates/) are responsible for displaying nodes (single pages) of collections. Templates are usually located in `src/templates`. Gridsome tries to locate a file with the same name as the Collection if no component has been specified in templates config.
 
 Here is an example:
@@ -41,6 +44,7 @@ query ($id: ID!) {
 [Learn more about Templates](/docs/templates/)
 
 ## Layouts
+
 Layouts are **Vue Components** that are used inside Pages and Templates to wrap the content. A layout usually contains Header & Footer.
 
 Layouts are usually used like this in Pages:
@@ -67,13 +71,14 @@ export default {
 
 [Learn more about Layouts](/docs/layouts/)
 
-
 ## Images
+
 Gridsome has a built-in `<g-image>` component that outputs an optimized progressive image. It also resizes and crops in real-time when developing if **width** and **height** is changed. `<g-images>` creates a super small **blurred inline base64 image** and then uses IntersectionObserver to lazy load image when in view.
 
 [Learn more about g-image](/docs/images/)
 
 ## Linking
+
 Gridsome has a built-in `<g-link>` component that uses IntersectionObserver to prefetch linked pages when the link is in view. This makes browsing around in a Gridsome site very fast because the clicked page is already downloaded.
 
 [Learn more about g-link](/docs/linking/)

--- a/docs/custom-css.md
+++ b/docs/custom-css.md
@@ -1,2 +1,3 @@
 # Custom CSS
+
 ...

--- a/docs/custom-fonts.md
+++ b/docs/custom-fonts.md
@@ -1,2 +1,3 @@
 # Custom fonts
+
 ...

--- a/docs/data-layer.md
+++ b/docs/data-layer.md
@@ -10,16 +10,14 @@ If you need dynamic data you should use [client-side data](/docs/client-side-dat
 
 💡 **Pages and Site metadata are added to the data layer by default.**
 
-
-
 ## Working with data
+
  - [How to import data](/docs/fetching-data/).
  - [How to query data](/docs/querying-data/).
  - [How to filter data](/docs/filtering-data/).
  - [How to create taxonomy pages](/docs/taxonomies/).
  - [How to paginate data](/docs/pagination/).
  - [How to add client-side / dynamic data](/docs/client-side-data/).
-
 
 ## The GraphQL explorer
 

--- a/docs/deploy-to-amazon-s3.md
+++ b/docs/deploy-to-amazon-s3.md
@@ -1,4 +1,5 @@
 # Deploy to Amazon s3
+
 The easiest way to host a static site on the blazing-fast S3 is to use the wonderful tool Up. Up deploys static websites in seconds, so you can get back to working on what makes your product unique. Learn more about Up here: https://apex.sh/docs/up/
 
 **Follow the instructions here to get started:**

--- a/docs/deploy-to-firebase.md
+++ b/docs/deploy-to-firebase.md
@@ -44,7 +44,9 @@ Create firebase.json and .firebaserc at the root of your project with the follow
  }
 }
 ```
+
 ## Step 3: Deploying
+
 Deploying Your Site
 
 ```shell script

--- a/docs/deploy-to-google.md
+++ b/docs/deploy-to-google.md
@@ -1,5 +1,7 @@
 # Deploy to Google Cloud Platform
+
 ## Prerequisites:
+
       1. Create a project op Google Cloud Platform
       2. Have acces to DNS record of your domain
       
@@ -11,7 +13,9 @@ Please follow this [tutorial](https://cloud.google.com/storage/docs/hosting-stat
 The HTTPS configuration is a bit more complex.
 
 # Steps to complete
+
 ## Use a Cloud Storage bucket as a load balancer backend
+
  Steps:
  
       1. Configure a Cloud Storage bucket
@@ -21,16 +25,18 @@ The HTTPS configuration is a bit more complex.
 Please follow the steps in the well documented Google [tutorial](https://cloud.google.com/load-balancing/docs/https/adding-a-backend-bucket-to-content-based-load-balancing)
 
 ## Set main and error page for bucket
+
 gsutil web set -m index.html -e 404.html gs://your-bucket-name
 [Documentation](https://cloud.google.com/storage/docs/gsutil/commands/web)
 
-
-
 # Google cloud build
+
 ## Setup Google Source Repositories 
+
 [Documentation](https://cloud.google.com/source-repositories/docs/)
 
 ## Add Build trigger
+
 Create a new [trigger](https://console.cloud.google.com/cloud-build/triggers)
 
 
@@ -49,5 +55,6 @@ args: ["-m", "rsync", "-r", "-c", "-d", "./dist", "gs://bucket-name"]
 Last build step is to push static files to your bucket
 
 ## Link DNS record to reserved external Google IP
+
 You must link these to resolve your domain to our external Google IP address.
 This can be done in your DNS service

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -22,6 +22,7 @@ These services are great for Git-based deploying:
 - [Surge.sh](/docs/deploy-to-surge-sh/)
 
 ## Deploy from terminal
+
 Many services let you deploy your static Gridsome site from the terminal. Here are some:
 
 - [Amazon S3](/docs/deploy-to-amazon-s3/)

--- a/docs/dev-tools.md
+++ b/docs/dev-tools.md
@@ -2,8 +2,8 @@
 
 Tools for easier Gridsome development
 
-
 ## ESLint plugin
+
 https://www.npmjs.com/package/eslint-plugin-gridsome
 
 ## Vetur

--- a/docs/directory-structure.md
+++ b/docs/directory-structure.md
@@ -89,6 +89,7 @@ The `App.vue` file is the main component that wraps all your pages and templates
 Files in this directory will be copied directly to `dist` during build. For example, **/static/robots.txt** will be located at https://yoursite.com/robots.txt
 
 ## Aliases
+
 In Gridsome you can use the aliases `~` or `@` to link to files inside the `/src` folder. For example, you can import a Vue component by using `import Card from '~/components/Card'`
 
 ## Recommendation

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,13 +1,13 @@
 # FAQ
 
-
 ### What kind of websites can I build with Gridsome?
+
 Gridsome is a static site generator by heart, but since it's using Vue.js for frontend, you can add any dynamic content on top of the static content. This makes it possible to build any kind of CDN-ready websites and serverless apps with it.
 
-
 ### Can I use Gridsome for large websites?
+
 Gridsome can generate thousands of pages in seconds so you can build pretty large sites without any problems. You need to think of the build process is almost the same as waiting for the cache to propagate. It's strongly recommended to use continuous deployment services like **Netlify** or **AWS Amplify Console** to auto re-build site on content changes.
 
-
 ### How can content editors preview drafts?
+
 This is not easy right now without building custom solutions. There will be simple preview services in the future that will make this easy.

--- a/docs/fast-by-default.md
+++ b/docs/fast-by-default.md
@@ -1,7 +1,9 @@
 # Fast by default
+
 > Gridsome builds ultra performance into every page automatically. You get code splitting, asset optimization, progressive images, and link prefetching out of the box. With Gridsome you get almost perfect page speed scores by default.
 
 ## What makes Gridsome sites fast?
+
 1. [Pre-rendered HTML](#pre-rendered-html). Nothing beats static content in speed.
 2. [Automatic Code Splitting](#automatic-code-splitting) so only what you need is loaded per page.
 2. [Follows the PRPL-pattern](#the-prpl-pattern) for instant page loads.
@@ -21,10 +23,9 @@ A static site gives you many benefits:
 
 - ⚡️ **Cheaper, Easier Scaling.** When your deployment amounts to a stack of files that can be served anywhere, scaling is a matter of serving those files in more places. CDNs are perfect for this, and often include scaling in all of their plans.
 
-
 ## Automatic Code splitting
-Every `import` you declare gets bundled and served with each page. That means pages never load unnecessary code while browsing around.
 
+Every `import` you declare gets bundled and served with each page. That means pages never load unnecessary code while browsing around.
 
 ## The PRPL pattern
 
@@ -37,9 +38,8 @@ PRPL is a pattern for structuring and serving Progressive Web Apps (PWAs), with 
 
 Learn more about [PRPL pattern](https://developers.google.com/web/fundamentals/performance/prpl-pattern/)
 
-
-
 ## Smart link prefetching
+
 Gridsome prefetches internal links in the background so browsing around goes insanely fast. It uses the built-in `<g-link>` component and **Intersection Observer** to prefetch when the link is in view.
 
 Gridsome builds two files of every page. A static HTML and a small JavaScript file. When the website hydrates into a Vue.js-SPA, the link prefetching only loads the JavaScript to render the next page. This results in a faster and smoother browsing experience.
@@ -47,6 +47,7 @@ Gridsome builds two files of every page. A static HTML and a small JavaScript fi
 [Learn more about **g-link** here](/docs/linking/).
 
 ## Progressive Images
+
 Gridsome has a built-in `<g-image>` component with automatic progressive image support. In **development** it lets you do real-time image processing, like resizing and cropping.
 
 In production, the `<g-image>` is served as an ultra-compressed image before the image is lazy-loaded when in view by using **Intersection Observer**.
@@ -54,8 +55,8 @@ In production, the `<g-image>` is served as an ultra-compressed image before the
 
 [Learn more about **g-image** here](/docs/images/)
 
-
 ## Vue.js SPA
+
 The `gridsome build` command generates **SEO-friendly HTML files** that can be hosted anywhere. These HTML files are optimized to load as fast as possible. After the HTML is loaded Vue.js takes over the HTML and **hydrates into a fully Vue-powered SPA.**
 
 **When SPA kicks in it only loads small code-splitted JS chunks for next pages.**

--- a/docs/fetching-data.md
+++ b/docs/fetching-data.md
@@ -1,7 +1,9 @@
 # Importing data
+
 Gridsome lets you import data from any data source into the [GraphQL data layer](/docs/data-layer/).
 
 ## Import with source plugins
+
 The easiest way to add data to Gridsome is to use **source plugins**. Gridsome data source plugins are added in `gridsome.config.js`. You can find available data source plugins in the [Plugins directory](/plugins).
 
 Here is an example of the [file-system](/plugins/@gridsome/source-filesystem) source added to config:
@@ -53,11 +55,12 @@ module.exports = function (api) {
 
 > Data is fetched when starting a development server or start of a production build. You need to restart the server for the changes in **gridsome.server.js** to take effect.
 
-
 ## Import from local files
+
 *..contribute*
 
 ### Markdown
+
 Import data into the GraphQL layer from markdown files by using the [transformer-remark](/plugins/@gridsome/transformer-remark) plugin.
 
 ```js
@@ -78,12 +81,15 @@ module.exports = {
 For more details on how to use this plugin, refer to the [plugin page](/plugins/@gridsome/transformer-remark) on this site.
 
 ### Images
+
 *..contribute*
 
 ### YAML
+
 *..contribute*
 
 ### CSV
+
 To import data from a CSV file, use one of the many CSV importers available for NodeJS. In this example, we use [csv-parse](https://www.npmjs.com/package/csv-parse). First we install our new package:
 
 ```
@@ -123,6 +129,7 @@ module.exports = function (api) {
 ```
 
 ### JSON
+
 Import data from any json file to the GraphQL data layer with the [Data store API](/docs/data-store-api/). To use the API you need a `gridsome.server.js` file in the root folder of your Gridsome project.
 
 

--- a/docs/guide-comments.md
+++ b/docs/guide-comments.md
@@ -3,9 +3,11 @@
 Adding comments to a static site can be easy, you have the option to use either external services that load an iframe into your site or applications that connect to your GitHub repository which commits the changes made on your site. We have listed some great services that integrate well with Gridsome.
 
 ## Disqus
+
 Disqus is an external service that injects an iframe on your site, one easy way to use Disqus with Gridsome is to use the package [vue-disqus](https://github.com/ktquez/vue-disqus) that provides you with a custom component that you can use across your project.
 
 #### Sign up on Disqus
+
 First step is to sign up for an account on [Disqus](https://disqus.com/). When presented with the option you want to choose 'I want to install Disqus on my site'. Continue by filling in all necessary information about your site and when you are asked 'What platform is your site on?', pick 'Universal Code' at the bottom of the page.
 
 Complete the setup of your site and take note of your `Shortname` because this will be used later.
@@ -13,6 +15,7 @@ Complete the setup of your site and take note of your `Shortname` because this w
 ![shortname](https://i.imgur.com/Ui1aoYi.png)
 
 #### Install vue-disqus
+
 You can use vue-disqus for easier implementation or use disqus directly, but this guide is using vue-disqus.
 
 `yarn add vue-disqus`
@@ -40,5 +43,6 @@ You need to provide a shortname which you can find on [Disqus](https://disqus.co
 Read more: [Disqus](https://disqus.com/)
 
 ## Staticman
+
 Staticman is an application that you connect to your GitHub repository which commits comments or any other type of user input to your site that you have configured.
 Read more: [Staticman](https://staticman.net/)

--- a/docs/guide-forms.md
+++ b/docs/guide-forms.md
@@ -2,20 +2,23 @@
 
 Adding forms to a static site is easy, but you need to use an external service. We have listed some great services that integrate well with Gridsome.
 
-
 ## Formspree
+
 Formspree is a contact form service that lets you handle form submission and it integrates seamlessly with your static sites 
 Read more: [Formspree](https://formspree.io/)
 
 ## Getform.io
+
 Getform is a form backend platform that lets you handle your forms on your websites and apps. You can set up a form and start collecting submissions to your form within minutes.
 Read More: [Getform](https://getform.io/)
 
 ## Form-Data
+
 Collect form submissions with spam filtering, email notifications, auto-reply and full automation. Free plan available. 
 Read More: [form-data](https://www.form-data.com/)
 
 ## Netlify Forms
+
 Netlify offers some sophisticated features to make static site form submissions a breeze.
 
 First we will start by adding the form to our template tag:
@@ -96,5 +99,6 @@ methods: {
 Read more: [Netlify Forms](https://www.netlify.com/docs/form-handling/)
 
 ## Basin
+
 Basin helps you manage form submission and track conversions with no backend coding required. It offers great features that integrate excellently with your static sites.
 Read More: [Basin](https://usebasin.com/)

--- a/docs/head.md
+++ b/docs/head.md
@@ -2,9 +2,11 @@
 title: Populating <head>
 ---
 # Populating `<head>`
+
 Gridsome uses [vue-meta](https://github.com/nuxt/vue-meta) to populate **Head**.
 
 ## Add global head metadata
+
 Global head metadata is added in `src/main.js` by using `head.{property}.push()`
 
 ```js
@@ -36,6 +38,7 @@ export default function (Vue, { head }) {
 ```
 
 ## Add head meta data to pages & templates
+
 Page metadata is added inside page **.vue components**.
 For example, `src/pages/About.vue` would look something like this:
 
@@ -124,4 +127,3 @@ Gridsome is passing `tagIdKeyName: 'key'` to vue-meta as default option.
 |title | Changes title text | [Docs](https://github.com/declandewet/vue-meta#title-string)
 |titleTemplate | Dynamic title text |  [Docs](https://github.com/declandewet/vue-meta#titletemplate-string--function)
 |link  | Adds a link tag | [Docs](https://github.com/declandewet/vue-meta#link-object)
-

--- a/docs/how-to-contribute.md
+++ b/docs/how-to-contribute.md
@@ -1,11 +1,12 @@
 # How to contribute
+
 > Gridsome is an open-source project built by core maintainers and contributors. We want to make it easy for anyone to contribute to Gridsome. Contribute to core, build plugins, improve documentation or write a blog post. It all helps Gridsome on its mission to simplify Jamstack development.
 
 Read the [code of conduct](/docs/code-of-conduct/).
 
 ## Contributing to Core
-Gridsome uses a **monorepo** pattern to manage its dependencies and core plugins. To contribute to core you need to install Gridsome core locally. This also enables you to run **personal Gridsome projects** on latest **Gridsome development** version.
 
+Gridsome uses a **monorepo** pattern to manage its dependencies and core plugins. To contribute to core you need to install Gridsome core locally. This also enables you to run **personal Gridsome projects** on latest **Gridsome development** version.
 
 ### Run Gridsome core locally
 
@@ -20,10 +21,9 @@ To use `@gridsome/cli` in the repo as a global command. Enter the `~/packages/cl
 
 **Yarn** will add dependencies from your test projects to the root `yarn.lock` file. So you should not commit changes in that file unless you have added dependencies to any of the core packages. If you need to commit it, remove your projects from the `~/projects` folder temporary and run `yarn` or `lerna bootstrap` in the root folder. Yarn will then clean up the lock file with only core dependencies. Commit the file and move your projects back and run `yarn` or `lerna bootstrap` again to start developing.
 
-
 ## Contributing to the docs
-We are a strong believer that documentation is very important for any open-source projects. Gridsome uses, of course, Gridsome for its website and documentation.
 
+We are a strong believer that documentation is very important for any open-source projects. Gridsome uses, of course, Gridsome for its website and documentation.
 
 1. If you want to add/modify any Gridsome documentation, go to the
    [docs folder on GitHub](https://github.com/gridsome/gridsome.org/tree/master/docs) and
@@ -32,8 +32,8 @@ We are a strong believer that documentation is very important for any open-sourc
 
 You can also clone [the Gridsome.org repo](https://github.com/gridsome/gridsome.org) and work locally on documentation. Install it like any other Gridsome project.
 
-
 ## Contributing to the blog
+
 Creating guest blog posts for Gridsome.org users is a great way to contribute to Gridsome community. A typical blog post could be: **How our company is using Gridsome to do XX**, or **How to integrate XX with Gridsome**.
 
 To add a new blog post to the gridsome.org blog:
@@ -57,7 +57,6 @@ To add a new blog post to the gridsome.org blog:
 - Commit and push to your fork
 - Create a pull request from your branch
   - We recommend using a prefix of `docs`, like `docs/your-change`.
-
 
 ## Submit a Starter
 
@@ -90,6 +89,6 @@ To add your Starter to gridsome.org:
 - Commit and push to your fork
 - Create a pull request from your branch
 
-
 ## Submit to Showcase *
+
 *Coming soon...*

--- a/docs/how-to-upgrade.md
+++ b/docs/how-to-upgrade.md
@@ -5,6 +5,6 @@ Follow **one** of these steps to upgrade Gridsome to latest version.
 - With **yarn** run `yarn upgrade gridsome --latest`
 - With **npm** run `npm install gridsome@latest`
 
-
 ### Problems after upgrading
+
 If you have problems after upgrading try remove `.cache` folder and run `yarn` again.

--- a/docs/images.md
+++ b/docs/images.md
@@ -11,8 +11,6 @@ A typical image component will look like this:
 
 📣 **Only local, relative image paths will be compressed by Gridsome.**
 
- 
-
 ## How it works
 
 - **A IMG element with a source srcset is used.** This means that using several media queries, you load the smallest image that matches your device (e.g. mobile devices get smaller images, desktop devices get larger images, etc.). The images will be resized down to 480, 1024, 1920 and 2560 pixels by default.
@@ -20,7 +18,6 @@ A typical image component will look like this:
 - **A base64 blurred image loaded by default.** This makes: 1) Larger images outside the viewport are not requested until they’re needed, and 2) The blurred image is in a container with the same dimensions as the real image—therefore, no jumping when the image loads.
 
 - **An Intersection Observer** that swaps the base image for the larger image, when the image is in the viewport. (Lazy loading).
-
 
 ## Usage in Vue templates
 
@@ -31,6 +28,7 @@ A `<g-image>` component is available in all your Vue templates and can be used t
 ```
 
 ## Usage via GraphQL
+
 Local image paths from sources can also be compressed. Options like `width`, `height` and `quality` must be set in the query. The field can be passed to `g-image` as the `src` attribute.
 
 ```html
@@ -50,6 +48,7 @@ query ($id: ID!) {
 ```
 
 ## Usage in Markdown
+
 The [@gridsome/transformer-remark](/plugins/@gridsome/transformer-remark) transformer plugin automatically converts normal Markdown images to `g-image` compatible markup.
 
 ```md
@@ -57,6 +56,7 @@ The [@gridsome/transformer-remark](/plugins/@gridsome/transformer-remark) transf
 ```
 
 ## Image cropping
+
 Crop the image by settings both `width` and `height` attributes. The image will be cropped to cover both dimensions by default. Change how to crop with the [`fit`](/docs/images#fit-options) attribute.
 
 ```html

--- a/docs/jamstack.md
+++ b/docs/jamstack.md
@@ -9,30 +9,25 @@
 
 Why wait for pages to build on the fly when you can generate them at deploy time? When it comes to minimizing the time to first byte, nothing beats pre-built files served over a CDN.
 
-
 ### ⚡️ Higher Security
 
 With server-side processes abstracted into microservice APIs, surface areas for attacks are reduced. You can also leverage the domain expertise of specialist third-party services.
-
 
 ### ⚡️ Cheaper, Easier Scaling
 
 When your deployment amounts to a stack of files that can be served anywhere, scaling is a matter of serving those files in more places. CDNs are perfect for this, and often include scaling in all of their plans.
 
-
 ### ⚡️ Better Developer Experience
 
 Loose coupling and separation of controls allow for more targeted development and debugging, and the expanding selection of CMS options for site generators remove the need to maintain a separate stack for content and marketing.
 
-
 ## Best practices
-When building Jamstack projects, you can really get the most out of the stack if you stick to a few best practices.
 
+When building Jamstack projects, you can really get the most out of the stack if you stick to a few best practices.
 
 ### Entire Project on a CDN
 
 Because Jamstack projects don’t rely on server-side code, they can be distributed instead of living on a single server. Serving directly from a CDN unlocks speeds and performance that can’t be beat. The more of your app you can push to the edge, the better the user experience.
-
 
 ### Everything Lives in Git
 
@@ -45,8 +40,6 @@ Take advantage of the world of modern build tools. It can be a jungle to get ori
 ### Automated Builds
 
 Because Jamstack markup is prebuilt, content changes won’t go live until you run another build. Automating this process will save you lots of frustration. You can do this yourself with webhooks, or use a publishing platform that includes the service automatically.
-
-
 
 ## Learn more
 

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -17,8 +17,8 @@ Layouts are _just_ &nbsp;**.vue components** located in `src/layouts` and need t
 </template>
 ```
 
-
 ## Import layouts
+
 When you have created a layout you need to import it to your pages and templates. This is done inside the `<script>` tag.
 
 ```html
@@ -41,8 +41,8 @@ export default {
 
 ```
 
-
 ## Make a layout global
+
 If you don't want to import the layout into every page or template you can make a layout global. To make a layout global go to `src/main.js` and import your layout file into this file.
 
 For example: 
@@ -76,8 +76,8 @@ You can now use `<Layout>` anywhere in your Gridsome project without importing i
 
 ```
 
-
 ## Passing Props to layouts
+
 Since layouts work like components, it is possible to pass Props to layouts. For example a page can look like this:
 
 
@@ -113,6 +113,7 @@ export default {
 ```
 
 ## Multiple content slots
+
 To add multiple slots to a layout you need to name them. In this example we have added a sidebar slot that will only show if the page has sidebar content.
 
 ```html
@@ -143,6 +144,7 @@ Pages can now add content to this slot like this:
 ```
 
 ## Master layout
+
 You can create a **master layout** by adding an **App.vue** file to `src` root. This will let you keep your header, footer on all pages and add **page transitions**.
 
 A simple **App.vue** file looks like this:

--- a/docs/page-transitions.md
+++ b/docs/page-transitions.md
@@ -4,8 +4,8 @@ Gridsome is mounting & unmounting the whole layout on route change. This happens
 
 ✌️ If you want to keep, for example, Header and Footer between page transitions you'll need to [override App.vue](/docs/overriding-app/) and add a transition there.
 
-
 ## Create an Enter transition
+
 To make [transitions](https://vuejs.org/v2/guide/transitions.html) work now you need to use only **Enter transitions**. You can do this by adding a `appear` attribute to `<transition>`.
 
 Here is an example where we **fade in** content on route change in a [layout](/docs/layouts/):

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -2,7 +2,6 @@
 
 To get started with Gridsome, you’ll need to make sure you have the following software tools installed:
 
-
 ### Node.js
 
 Visit the [Node.js site](https://nodejs.org/) and follow the instructions to download and install the recommended version for your operating system. Once you have followed the installation steps, make sure everything was installed properly:
@@ -13,7 +12,7 @@ Open up your terminal.
 - Run `npm --version`.
 - **The output of each of those commands should be a version number**. If entering those commands doesn’t show you a version number, go back and make sure you have installed **Node.js**.
 
-
 ### Yarn (Optional)
+
 Yarn is a fast alternative to Npm. It's optional to install, but recommended since we use it in many code examples.
 **Follow instruction here to install**: https://yarnpkg.com/en/docs/install

--- a/docs/starters.md
+++ b/docs/starters.md
@@ -6,26 +6,30 @@ Usage `gridsome create {name} {starter}`
 - **starter** - optional starter kit name or Git-repo url.
 
 ### Default
+
 The default project that is created with Gridsome CLI.
 
 `gridsome create my-website`
 
 [Learn more](https://github.com/gridsome/gridsome-starter-default)
 
-
 ### WordPress
+
 `gridsome create my-website wordpress`
 
 [Learn more](https://github.com/gridsome/gridsome-starter-wordpress)
 
 
-### Git-repositories:
+### Git-repositories
+
 #### gridsome-starter-markdown-blog
+
 `gridsome create my-website https://github.com/gridsome/gridsome-starter-markdown-blog.git`
 
 [Learn more](https://github.com/gridsome/gridsome-starter-markdown-blog.git)
 
 #### gridsome-starter-blog
+
 `gridsome create my-website https://github.com/gridsome/gridsome-starter-blog.git`
 
 [Learn more](https://github.com/gridsome/gridsome-starter-blog)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,4 +11,5 @@ chainWebpack (config) {
 ```
 
 ### Problems after an upgrade
+
 If you have problems after upgrading try remove `.cache` and `node_modules` folder and run `yarn` again. 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,29 +1,27 @@
 # Use cases
 
-
 ### Static Websites
-Build static websites with
-Markdown or any Headless CMS for content. Perfect for blogs and company websites.
+
+Build static websites with Markdown or any Headless CMS for content. Perfect for blogs and company websites.
 
 ### PWA for eCommerce
+
 Connect to popular eCommerce platforms and create blazing-fast PWA & SPA mobile-first front-ends
 
 - WooCommerce
 - Shopify
 - Magento
 
-
 ### Landing pages
 
-
 ### Documentation
-Create documentation with
-Markdown files.
+
+Create documentation with Markdown files.
 
 ### Design systems
-Combine Markdown and Vue Components to
-create design systems for companies.
 
+Combine Markdown and Vue Components to create design systems for companies.
 
 ### Front-end for any Headless CMS
+
 Connect to any Headless cms to build a static front-end

--- a/learn/dev-setup.md
+++ b/learn/dev-setup.md
@@ -5,14 +5,17 @@
 ## The command-line
 
 ## Install node.js
+
 Download and install from [NodeJS.org](https://nodejs.org/)
 
 Verify with `node --version` and `npm --version` in your terminal/powershell/command prompt
 
 ## Install GIT
+
 Follow the instructions [here](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 
 For Windows, if you have Chocolatey installed, run `choco install git`
 
 ## Install Gridsome Cli
+
 Run `npm install --global @gridsome/cli`


### PR DESCRIPTION
Update headers so that all documents observe the convention of having a single blank line before and after headers.
Update the markdownlint config to catch violations of this convention in the future.