### PR TITLE
Fix formatting on Google Cloud Platform deploy page

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -35,7 +35,5 @@ MD037: false
 MD040: false
 # first-line-heading/first-line-h1
 MD041: false
-# code-block-style
-MD046: false
 # single-trailing-newline
 MD047: false

--- a/docs/deploy-to-google.md
+++ b/docs/deploy-to-google.md
@@ -1,9 +1,9 @@
 # Deploy to Google Cloud Platform
 
-## Prerequisites:
+## Prerequisites
 
-      1. Create a project op Google Cloud Platform
-      2. Have acces to DNS record of your domain
+1. Create a project op Google Cloud Platform
+2. Have acces to DNS record of your domain
 
 You can host a static website on a Google Cloud Storage bucket for a domain you own.
 
@@ -12,48 +12,47 @@ Please follow this [tutorial](https://cloud.google.com/storage/docs/hosting-stat
 
 The HTTPS configuration is a bit more complex.
 
-# Steps to complete
-
 ## Use a Cloud Storage bucket as a load balancer backend
 
- Steps:
-
-      1. Configure a Cloud Storage bucket
-      2. Configure a load balancing service
-      3. Create an external address
+1. Configure a Cloud Storage bucket
+2. Configure a load balancing service
+3. Create an external address
 
 Please follow the steps in the well documented Google [tutorial](https://cloud.google.com/load-balancing/docs/https/adding-a-backend-bucket-to-content-based-load-balancing)
 
-## Set main and error page for bucket
+### Set main and error page for bucket
 
+```shell
 gsutil web set -m index.html -e 404.html gs://your-bucket-name
+```
+
 [Documentation](https://cloud.google.com/storage/docs/gsutil/commands/web)
 
-# Google cloud build
+## Google cloud build
 
-## Setup Google Source Repositories
+### Setup Google Source Repositories
 
 [Documentation](https://cloud.google.com/source-repositories/docs/)
 
-## Add Build trigger
+### Add Build trigger
 
 Create a new [trigger](https://console.cloud.google.com/cloud-build/triggers)
 
-Add a cloudbuild.yaml to the root of the project containing
+Add a `cloudbuild.yaml` to the root of the project containing:
 
-```
+```yaml
 steps:
-- name: 'gcr.io/cloud-builders/npm'
-args: ['install']
-- name: 'gcr.io/cloud-builders/npm'
-args: ['run' , 'build']
-- name: 'gcr.io/cloud-builders/gsutil'
-args: ["-m", "rsync", "-r", "-c", "-d", "./dist", "gs://bucket-name"]
+  - name: 'gcr.io/cloud-builders/npm'
+    args: ['install']
+  - name: 'gcr.io/cloud-builders/npm'
+    args: ['run' , 'build']
+  - name: 'gcr.io/cloud-builders/gsutil'
+    args: ["-m", "rsync", "-r", "-c", "-d", "./dist", "gs://bucket-name"]
 ```
 
-Last build step is to push static files to your bucket
+Last build step is to push static files to your bucket.
 
-## Link DNS record to reserved external Google IP
+### Link DNS record to reserved external Google IP
 
 You must link these to resolve your domain to our external Google IP address.
 This can be done in your DNS service


### PR DESCRIPTION
The headers were inconsistent and the lists were being formatted as code blocks. This fixes those issues and configures the linter to catch future violations.