### PR TITLE
Divide markdown lint rules into categories

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -14,17 +14,17 @@ MD024: false
 # like that.
 MD026: false
 
-# no-bare-urls
-# The linter flags http://example.com and wants them formatted like
-# <http://example.com>, but this doesn't improve readability.
-MD034: false
-
 # no-inline-html
 MD033:
   # We use inline HTML to embed the Newsletter component in a page.
   allowed_elements:
     - div
     - Newsletter
+
+# no-bare-urls
+# The linter flags http://example.com and wants them formatted like
+# <http://example.com>, but this doesn't improve readability.
+MD034: false
 
 # Note: Because this repo started without a linter, the rules below are
 # suppressed for compatibility with legacy code, but we should either fix the

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,4 +1,8 @@
 ---
+# line-length
+# Markdown files don't need to observe a line length limit.
+MD013: false
+
 # no-trailing-punctuation
 # Without this rule suppression, the linter flags trailing punctuation in
 # headers like "## What makes Gridsome sites fast?" but we allow headers
@@ -27,8 +31,6 @@ MD033:
 MD001: false
 # ul-indent
 MD007: false
-# line-length
-MD013: false
 # no-duplicate-heading/no-duplicate-header
 MD024: false
 # single-title/single-h1

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,7 +1,27 @@
 ---
-# Note: Because this repo started without a linter, we're starting with
-# extremely permissive rules. We'll tighten up these rules over time as we
-# fix previous linter errors.
+# no-trailing-punctuation
+# Without this rule suppression, the linter flags trailing punctuation in
+# headers like "## What makes Gridsome sites fast?" but we allow headers
+# like that.
+MD026: false
+
+# no-bare-urls
+# The linter flags http://example.com and wants them formatted like
+# <http://example.com>, but this doesn't improve readability.
+MD034: false
+
+# no-inline-html
+MD033:
+  # We use inline HTML to embed the Newsletter component in a page.
+  allowed_elements:
+    - div
+    - Newsletter
+
+# Note: Because this repo started without a linter, the rules below are
+# suppressed for compatibility with legacy code, but we should either fix the
+# linter errors and remove the exceptions or explicitly choose to ignore the
+# rule permanently and move it to the list above with an explanation of why we
+# ignore the rule.
 
 # heading-increment/header-increment
 MD001: false
@@ -13,8 +33,6 @@ MD013: false
 MD024: false
 # single-title/single-h1
 MD025: false
-# no-trailing-punctuation
-MD026: false
 # ol-prefix
 MD029: false
 # list-marker-space
@@ -23,12 +41,6 @@ MD030: false
 MD031: false
 # blanks-around-lists
 MD032: false
-# no-inline-html
-MD033:
-  # We use inline HTML to embed the Newsletter component in a page.
-  allowed_elements:
-    - div
-    - Newsletter
 # no-bare-urls
 MD034: false
 # no-emphasis-as-heading/no-emphasis-as-header

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -3,6 +3,11 @@
 # Markdown files don't need to observe a line length limit.
 MD013: false
 
+# no-duplicate-heading/no-duplicate-header
+# It's acceptable to have duplicate headers in the same file sometimes, like
+# when multiple sections have a subsection called "### Example".
+MD024: false
+
 # no-trailing-punctuation
 # Without this rule suppression, the linter flags trailing punctuation in
 # headers like "## What makes Gridsome sites fast?" but we allow headers
@@ -31,8 +36,6 @@ MD033:
 MD001: false
 # ul-indent
 MD007: false
-# no-duplicate-heading/no-duplicate-header
-MD024: false
 # single-title/single-h1
 MD025: false
 # ol-prefix

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -46,8 +46,6 @@ MD030: false
 MD031: false
 # blanks-around-lists
 MD032: false
-# no-bare-urls
-MD034: false
 # no-emphasis-as-heading/no-emphasis-as-header
 MD036: false
 # no-space-in-emphasis


### PR DESCRIPTION
There are two categories of custom markdown lint rules:

1. Rules we suppress because we consciously choose to ignore them.
1. Rules we suppress because of legacy code that violates it, but we may or may not fix the legacy code to make the linter pass.

This updates the rule list to make the distinction more clear.