### PR TITLE
Get rid of HTML embedded in Markdown

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -24,7 +24,11 @@ MD031: false
 # blanks-around-lists
 MD032: false
 # no-inline-html
-MD033: false
+MD033:
+  # We use inline HTML to embed the Newsletter component in a page.
+  allowed_elements:
+    - div
+    - Newsletter
 # no-bare-urls
 MD034: false
 # no-emphasis-as-heading/no-emphasis-as-header

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@
 
 ## How it works
 
-Gridsome **generates static html** that hydrates into a <strong>Vue SPA</strong> once loaded in the browser. This means you can build both **static websites** & **dynamic apps** with Gridsome.
+Gridsome **generates static html** that hydrates into a **Vue SPA** once loaded in the browser. This means you can build both **static websites** & **dynamic apps** with Gridsome.
 
 Gridsome builds one `.html` file and one `.json` file for every page. After first page load it only uses the `.json` files to prefetch and load data for the next pages. It also builds a `.js` bundle for each page that needs it (code splitting).
 

--- a/docs/deploy-to-surge-sh.md
+++ b/docs/deploy-to-surge-sh.md
@@ -42,10 +42,7 @@ surge dist/
 
 Done 🙂
 
->
-> __Note__: <br/>
-> If this is your first time using Surge, you'll be prompted to create a (free) account from the command line. This will only happen once.
->
+> **Note**: If this is your first time using Surge, you'll be prompted to create a (free) account from the command line. This will only happen once.
 
 ---
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,6 +1,6 @@
 # How it works
 
-Gridsome is a modern website development framework for creating fast and secure websites that can be deployed anywhere. Static HTML files are generated to create SEO-friendly markup that hydrates into a <strong>Vue.js-powered SPA</strong> once loaded in the browser.
+Gridsome is a modern website development framework for creating fast and secure websites that can be deployed anywhere. Static HTML files are generated to create SEO-friendly markup that hydrates into a **Vue.js-powered SPA** once loaded in the browser.
 
 Source plugins fetch content from local files or external APIs and store the data in a local database. A unified GraphQL data layer lets you extract only the data you need from the database and use it in your Vue.js components. The data is generated and stored as static JSON at build time.
 


### PR DESCRIPTION
We only really need it in one spot, so this adjusts the linter to allow that particular usage.