### PR TITLE
Update docs due to changes in webpack-node-externals options

### DIFF
--- a/docs/assets-css.md
+++ b/docs/assets-css.md
@@ -407,7 +407,7 @@ export default function (Vue, { appOptions, head }) {
 }
 ```
 
-Finally, there is one last thing you will need in order to build your application with Vuetify. You will need to whitelist Vuetify in webpack in order to build.
+Finally, there is one last thing you will need in order to build your application with Vuetify. You will need to allowlist Vuetify in webpack in order to build.
 
 First, install the webpack-node-externals plugin:
 
@@ -419,7 +419,7 @@ npm install webpack-node-externals --save-dev
 yarn add webpack-node-externals --dev
 ```
 
-Then modify your `gridsome.server.js` file to include the webpack-node-externals package, and whitelist Vuetify.
+Then modify your `gridsome.server.js` file to include the webpack-node-externals package, and allowlist Vuetify.
 ```js
 const nodeExternals = require('webpack-node-externals')
 
@@ -428,7 +428,7 @@ module.exports = function (api) {
     if (isServer) {
       config.externals([
         nodeExternals({
-          whitelist: [/^vuetify/]
+          allowlist: [/^vuetify/]
         })
       ])
     }
@@ -439,6 +439,7 @@ module.exports = function (api) {
   })
 }
 ```
+>❗️Note: Before webpack-node-externals version 2.4, use whitelist instead of allowlist.
 
 Or save your bundle size by using [vuetify treeshaking](https://vuetifyjs.com/en/customization/a-la-carte).
 


### PR DESCRIPTION
webpack-node-externals has been removed from the `whitelist` option in version 2.5 and is now an `allowlist`.

Update the documentation to use the new `allowlist` option.

Changes in webpack-node-externals
- [Include a warning when using whitelist instead of allowlist · Issue #76 · liady/webpack-node-externals](https://github.com/liady/webpack-node-externals/issues/76)
- [throw an error when using wrong spelling of an option · liady/webpack-node-externals@3b9069b](https://github.com/liady/webpack-node-externals/commit/3b9069bb81cb832e2b2087234b67ec2339f70c1b)