### PR TITLE
Destructured Item on Docs

### DIFF
--- a/docs/data-store-api.md
+++ b/docs/data-store-api.md
@@ -165,13 +165,13 @@ module.exports = function (api) {
 
     const collection = actions.addCollection('Post')
 
-    for (const item of data) {
+    for (const { id, title, slug, date, content } of data) {
       collection.addNode({
-        id: item.id,
-        title: item.title,
-        slug: item.slug,
-        date: item.date,
-        content: item.content
+        id,
+        title,
+        slug,
+        date,
+        content
       })
     }
   })


### PR DESCRIPTION
All may not agree with this PR, but I think that we should utilize javascript's full potential and just destructure the `item` variable instead of repeating `item` within our code. 