### PR TITLE
Revert "Update Example Usage > Create pages from GraphQL"

### DIFF
--- a/docs/pages-api.md
+++ b/docs/pages-api.md
@@ -131,13 +131,11 @@ query ($customValue: String) {
 module.exports = function (api) {
   api.createPages(async ({ graphql, createPage }) => {
     const { data } = await graphql(`{
-      query{
-        allProduct {
-          edges {
-            node {
-              id
-              slug
-            }
+      allProduct {
+        edges {
+          node {
+            id
+            slug
           }
         }
       }


### PR DESCRIPTION
Reverts gridsome/gridsome.org#494

This doesn't actually need the query wrapper (as GraphQL defaults to `query` type), or if it should be included for clarity, then the preceding { should be removed:

```js
graphql(`{ # either this
      query{ # or this should be removed
        allProduct {
```