### PR TITLE
Update deploy-to-github.md

### DIFF
--- a/docs/deploy-to-github.md
+++ b/docs/deploy-to-github.md
@@ -27,16 +27,13 @@ There's a few steps to complete:
 **Notes**
 
 GitHub Pages allows you to have a "GitHub user page" that acts as a profile/main page on `<your-github-username>.github.io` by having a repo named `<your-github-username>.github.io`.
-* If you are deploying to your GitHub user page (your main site on `<username>.github.io`):
-  * Make the following adjustments to your `package.json`:
-    ```json
-    - "deploy": "gh-pages -d dist",
-    + "deploy": "gh-pages -b master -d dist",
-    ```
-  * And Remove this line from `gridsome.config.js`:
+* If you are deploying to your GitHub user page (your main site on `<username>.github.io`) 
+  * Remove this line from `gridsome.config.js`:
     ```js
     - pathPrefix: '/<your-gridsome-repo-name>',
     ```
+  * Now when you run the `npm run deploy` command, your project will be built and the contents of the `dist` folder will be pushed to the `gh-pages` branch which is where your "Github user page" will deploy from.
+  * This also allows you to keep track of your project on the `master` branch (or any branch you want) while `gh-pages` only contains your built files. 
 * If you are using a custom URL such as `www.yourname.com` you will need to change `gridsome.config.js` to:
   ```js
   siteUrl: 'https://www.yourname.com',

--- a/docs/deploy-to-github.md
+++ b/docs/deploy-to-github.md
@@ -27,13 +27,13 @@ There's a few steps to complete:
 **Notes**
 
 GitHub Pages allows you to have a "GitHub user page" that acts as a profile/main page on `<your-github-username>.github.io` by having a repo named `<your-github-username>.github.io`.
-* If you are deploying to your GitHub user page (your main site on `<username>.github.io`) 
+* If you are deploying to your GitHub user page (your main site on `<username>.github.io`)
   * Remove this line from `gridsome.config.js`:
     ```js
     - pathPrefix: '/<your-gridsome-repo-name>',
     ```
   * Now when you run the `npm run deploy` command, your project will be built and the contents of the `dist` folder will be pushed to the `gh-pages` branch which is where your "Github user page" will deploy from.
-  * This also allows you to keep track of your project on the `master` branch (or any branch you want) while `gh-pages` only contains your built files. 
+  * This also allows you to keep track of your project on the `master` branch (or any branch you want) while `gh-pages` only contains your built files.
 * If you are using a custom URL such as `www.yourname.com` you will need to change `gridsome.config.js` to:
   ```js
   siteUrl: 'https://www.yourname.com',


### PR DESCRIPTION
Adding the `-b master` flag as suggested in the documentation causes your deployments from the `dist` folder to overwrite the `master` branch.

This PR suggests leaving out the flag so the user can continue managing the project with the master branch and only push built files to the `gh-pages` branch.