### PR TITLE
YAML no longer requires `safeLoad`

### DIFF
--- a/docs/fetching-data.md
+++ b/docs/fetching-data.md
@@ -111,7 +111,7 @@ const fs = require('fs');
 const yaml = require('js-yaml');
 
 const fileContents = fs.readFileSync('./src/data/products.yaml', 'utf8');
-const products = yaml.safeLoad(fileContents);
+const products = yaml.load(fileContents);
 
 module.exports = function (api) {
   api.loadSource(async actions => {


### PR DESCRIPTION
After update `js-yaml` library already preform safe load in normal `load()` function. As such `safeLoad` is deprecated and users should use `load()` instead.