### PR TITLE
Add a .editorconfig file to the project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Add a `.editorconfig` file to the project.

This allows to quickly set up the IDE, especially concerning spaces, tabulations, EOL and EOF.

cf. https://editorconfig.org/