### PR TITLE
Fix Bueify duplicate entry build error

### DIFF
--- a/starters/starters.yaml
+++ b/starters/starters.yaml
@@ -397,7 +397,7 @@
   tags: gridsome, starter, strapi, blog
   platforms: strapi
 
-- title: Buefy
+- title: Buefy Portfolio
   description: Buefy Portfolio Starter
   screenshot: ./screenshots/gridsome-starter-buefolio.png
   repo: yanuaraditia/gridsome-starter-buefolio
@@ -405,7 +405,6 @@
   author: yanuaraditia
   tags: markdown, portfolio, bulma, buefy, buefolio
   platforms: markdown
-
 
 - title: Gridsome Kontent Starter
   description: Lumen blog template implemented using Gridsome and Kentico Kontent


### PR DESCRIPTION
Fix `Starter > Failed to add node: Duplicate key for property path: /starters/buefy/` build error

before:
https://app.netlify.com/sites/gridsome-org/deploys/60202e0ed82af10008ce6467

after:
https://app.netlify.com/sites/gridsome-org/deploys/602030668ae79a0008f312e8