### PR TITLE
Block sass-loader version at 10

### DIFF
--- a/docs/assets-css.md
+++ b/docs/assets-css.md
@@ -22,6 +22,7 @@ npm install -D sass-loader@^10.1.1 node-sass
 # Using Yarn
 yarn add -D sass-loader@^10.1.1 node-sass
 ```
+The tag of version 10 for sass-loader is needed since version 11 is released because this version requires Webpack 5. Gridsome does not yet support webpack 5.
 
 Now you can import **.scss** files in **src/main.js**:
 

--- a/docs/assets-css.md
+++ b/docs/assets-css.md
@@ -17,10 +17,10 @@ To enable **SASS** you need to install the required packages:
 
 ```shell
 # Using npm
-npm install -D sass-loader node-sass
+npm install -D sass-loader@^10.1.1 node-sass
 
 # Using Yarn
-yarn add -D sass-loader node-sass
+yarn add -D sass-loader@^10.1.1 node-sass
 ```
 
 Now you can import **.scss** files in **src/main.js**:

--- a/docs/assets-css.md
+++ b/docs/assets-css.md
@@ -22,7 +22,7 @@ npm install -D sass-loader@^10.1.1 node-sass
 # Using Yarn
 yarn add -D sass-loader@^10.1.1 node-sass
 ```
-The tag of version 10 for sass-loader is needed since version 11 is released because this version requires Webpack 5. Gridsome does not yet support webpack 5.
+The tag of version 10 for `sass-loader` is needed, since version 11 requires Webpack 5 - which Gridsome does not yet support.
 
 Now you can import **.scss** files in **src/main.js**:
 


### PR DESCRIPTION
The latest version is 11 but need webapck 5, which is not yet used in Gridsome.
So with a simple `yarn add -D sass-loader` we have an exception during the build.