### PR TITLE
Add Netlify as a destination for terminal deployments

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -27,6 +27,7 @@ These services are great for Git-based deploying:
 Many services let you deploy your static Gridsome site from the terminal. Here are some:
 
 - [Amazon S3](/docs/deploy-to-amazon-s3/)
+- [Netlify](/docs/deploy-to-netlify/)
 
 - [Vercel](/docs/deploy-to-vercel/)
 


### PR DESCRIPTION
Netlify allows users to deploy Gridsome sites right from the terminal. This PR adds Netlify to the list of terminal deployment destinations in the Gridsome documentation site.