### PR TITLE
Add Netlify as a destination for terminal deployments

### DIFF
--- a/docs/deploy-to-netlify.md
+++ b/docs/deploy-to-netlify.md
@@ -37,7 +37,7 @@ npm install netlify-cli -g
 
 ```
 
-Login into your Netlify account via the CLI.
+Log in to your Netlify account via the CLI.
 
 ```bash
 netlify login

--- a/docs/deploy-to-netlify.md
+++ b/docs/deploy-to-netlify.md
@@ -34,28 +34,24 @@ Install the Netlify CLI.
 
 ```bash
 npm install netlify-cli -g
-
 ```
 
 Log in to your Netlify account via the CLI.
 
 ```bash
 netlify login
-
 ```
 
 In your project's folder run the deploy command.
 
 ```bash
 netlify deploy
-
 ```
 
 The default command `netlify deploy` will deploy a draft of the site. To deploy a live version, specify the prod flag.
 
 ```bash
 netlify deploy --prod
-
 ```
 
 **Note:**

--- a/docs/deploy-to-netlify.md
+++ b/docs/deploy-to-netlify.md
@@ -2,23 +2,61 @@
 
 Netlify is an excellent solution for deploying and hosting Gridsome sites. Netlify is a unified platform that automates your code to create high-performant, easily maintainable sites and web apps. They provide continuous deployment (Git-triggered builds), an intelligent, global CDN, full DNS (including custom domains), automated HTTPS, asset acceleration, and more.
 
-Their free tier includes unlimited personal and commercial projects, HTTPS, continuous deployment from public or private repos and more.
+Their free tier includes unlimited personal and commercial projects, HTTPS, continuous deployment from public or private repos and more. Here are a few ways to deploy your Gridsome applications to Netlify:
 
-To deploy your Gridsome site to Netlify, go to the create a new site page, select your project repo from GitHub, GitLab, or Bitbucket.
+## From your Git repository
+
+To deploy your Gridsome site to Netlify, go to your [Netlify app](https://app.netlify.com/) and click `New site from Git`. Select your project repo from either GitHub, GitLab, or Bitbucket.
 
 Add these build settings:
+
 - **Build Command:** `gridsome build`
 - **Publish directory:** `dist`
 
-Alternatively, you can deploy using a `netlify.toml` file. Create a file in the root of your project called `netlify.toml`, with the following configuation.
+And click `Deploy Site` to deploy your application.
+
+Alternatively, you can specify your deploy settings from a `netlify.toml` file. Create a file in the root of your project called `netlify.toml`, with the following configuation.
 
 ```toml
-  [build]
-    publish = "dist"
-    command = "gridsome build"
+[build]
+  publish = "dist"
+  command = "gridsome build"
 ```
 
+These commands will tell Netlify to prefill your build settings with the provided configuration when deploying your Gridsome application.
 More infomation on `netlify.toml` files can be found in the [Netlify docs](https://www.netlify.com/docs/netlify-toml-reference/).
+
+## From the terminal
+
+Netlify also allows you to deploy Gridsome applications directly from the terminal.
+
+Install the Netlify CLI.
+
+```bash
+npm install netlify-cli -g
+
+```
+
+Login into your Netlify account via the CLI.
+
+```bash
+netlify login
+
+```
+
+In your project's folder run the deploy command.
+
+```bash
+netlify deploy
+
+```
+
+The default command `netlify deploy` will deploy a draft of the site. To deploy a live version, specify the prod flag.
+
+```bash
+netlify deploy --prod
+
+```
 
 **Note:**
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -26,6 +26,8 @@ These services are great for Git-based deploying:
 
 Many services let you deploy your static Gridsome site from the terminal. Here are some:
 
+- [Netlify](/docs/deploy-to-netlify/)
+
 - [Amazon S3](/docs/deploy-to-amazon-s3/)
 
 - [Vercel](/docs/deploy-to-vercel/)


### PR DESCRIPTION
Netlify allows users to deploy Gridsome sites right from the terminal. This PR adds Netlify to the list of terminal deployment destinations in the Gridsome documentation site and also adds the terminal deployment instructions in the `/deploy-to-netlify/` page on the docs as requested in #592 