### PR TITLE
docs: add IONOS Deploy Now link to git-based deployments

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -22,6 +22,8 @@ These services are great for Git-based deploying:
 
 - [Azure Static Web Apps](/docs/deploy-to-az-static-web-app/)
 
+- [IONOS Deploy Now](/docs/deploy-to-ionos-deploy-now/)
+
 ## Deploy from terminal
 
 Many services let you deploy your static Gridsome site from the terminal. Here are some:


### PR DESCRIPTION
Adds a link to the IONOS Deploy Now page under git-based deployments in `/docs/deployment/`.