### PR TITLE
chore(docs): add stormkit to deployment guides

### DIFF
--- a/docs/deploy-to-stormkit.md
+++ b/docs/deploy-to-stormkit.md
@@ -1,0 +1,20 @@
+# Deploy to Stormkit
+
+Easily build, deploy and scale your Gridsome applications with [Stormkit.io](https://www.stormkit.io). It supports instant rollbacks, serverless-side logic, snippet injections, multiple environments, APIs and more...
+
+## Setup
+
+1. Go to [app.stormkit.io](https://app.stormkit.io) and log in by selecting your git provider.
+2. Once logged in, Stormkit will ask you in which provider your codebase is located. Click on the provider once more.
+3. If Github, click on ‘Connect more repositories’ and grant Stormkit access to it.
+4. Next, select your repository. This will create the application on Stormkit.
+5. On your application's page, click to the **Deploy** button.
+6. That's it! Your Gridsome project is ready to be served.
+
+## Hosting using Stormkit
+
+Stormkit generates a unique URL for each deployment. You can preview your application using these links. Later, you can connect your domain and publish any deployment so that the users will start to see that version of your application. You can also do staged-rollouts or A/B testing by publishing multiple versions at the same time.
+
+## Support
+
+If you need additional support, you can chat with Stormkit developers and other community members on [Discord](https://discord.gg/6yQWhyY).


### PR DESCRIPTION
Adds stormkit to deployment guides.

Here's an example app: https://gridsome-hello-world.stormkit.dev/
And the example repo: https://github.com/svedova/gridsome-hello-world

Importing and clicking `Deploy` button without any config deploys the project successfully.